### PR TITLE
Bump learnings and ledger formulas

### DIFF
--- a/Formula/learnings.rb
+++ b/Formula/learnings.rb
@@ -1,15 +1,15 @@
 class Learnings < Formula
   desc "Zig CLIs for Codex learnings capture workflows"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.1.21"
+  version "0.1.22"
   license "MIT"
 
   if OS.mac?
     url "https://github.com/tkersey/skills-zig/releases/download/learnings-v#{version}/learnings-v#{version}-darwin-arm64.tar.gz"
-    sha256 "e4ad77f574e396b715847e550874da69b3b02c8e791a45e332bf147099253a19"
+    sha256 "aae4545a8db0791ac80d1343f4e722110ef7084b9d1b05b25c88dbc344fd7d4f"
   else
     url "https://github.com/tkersey/skills-zig/releases/download/learnings-v#{version}/learnings-v#{version}-linux-x86_64.tar.gz"
-    sha256 "8b861f6aa56653458f4826c0f21e042b2084656975abb4cae6e8fdc6776649ec"
+    sha256 "1617691e081b467a25a3c6281fc8bb4fcfaeea04cddce4078a02bdc9835dbe94"
   end
 
   on_macos do
@@ -26,17 +26,20 @@ class Learnings < Formula
 
   test do
     learnings_help = shell_output("#{bin}/learnings --help 2>&1")
-    assert_match "Mine, recall, and promote records from repo-root .learnings.jsonl.", learnings_help
+    assert_match "Mine, recall, and promote records from repo-local", learnings_help
+    assert_match ".ledger/learnings/learnings.jsonl", learnings_help
     assert_match "append", learnings_help
+    assert_match "migrate", learnings_help
     assert_match "memory-digest", learnings_help
 
     append_subcommand_help = shell_output("#{bin}/learnings append --help 2>&1")
-    assert_match "Append a structured learning record", append_subcommand_help
+    assert_match "Append a structured learning record to repo-local", append_subcommand_help
+    assert_match ".ledger/learnings/learnings.jsonl", append_subcommand_help
 
     digest_help = shell_output("#{bin}/learnings memory-digest --help 2>&1")
     assert_match "memory-digest", digest_help
 
     append_help = shell_output("#{bin}/append_learning --help 2>&1")
-    assert_match "Append a structured learning record", append_help
+    assert_match "Append a structured learning record to repo-local .ledger/learnings/learnings.jsonl.", append_help
   end
 end

--- a/Formula/ledger.rb
+++ b/Formula/ledger.rb
@@ -1,15 +1,15 @@
 class Ledger < Formula
   desc "Zig CLI for repo-local durable negative-evidence ledgers"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.2.2"
+  version "0.2.3"
   license "MIT"
 
   if OS.mac?
     url "https://github.com/tkersey/skills-zig/releases/download/ledger-v#{version}/ledger-v#{version}-darwin-arm64.tar.gz"
-    sha256 "3c8bf71d1f006c74afde07ba1011bd348292cece03d174f0f6b3ce7b02a8212f"
+    sha256 "f6d88b9a196fdf5ec6ebcac18e2797b2a1d37ddb1f49888f4a6b4ea3efa7b0a2"
   else
     url "https://github.com/tkersey/skills-zig/releases/download/ledger-v#{version}/ledger-v#{version}-linux-x86_64.tar.gz"
-    sha256 "b4f83689e517cacfe20402c098f63d29db7739bf28e9fb4d130f18ed2d6e6985"
+    sha256 "feb29a996ff93ab9c13667a1eeeba0eb37e23954bf1ca1d9ce41406bc235c8a3"
   end
 
   on_macos do
@@ -32,11 +32,12 @@ class Ledger < Formula
     assert_match "Durable negative-evidence ledger.", help
     assert_match "capture", help
     assert_match "map", help
+    assert_match "migrate", help
     assert_match "status", help
     assert_match "export", help
 
     system bin/"ledger", "init"
-    assert_path_exists testpath/".ledger/negative-ledger.jsonl"
+    assert_path_exists testpath/".ledger/negative-ledger/events.jsonl"
     assert_match "\"ok\":true", shell_output("#{bin}/ledger doctor")
   end
 end


### PR DESCRIPTION
## Summary
- bump learnings to 0.1.22
- bump ledger to 0.2.3
- update release asset checksums and formula tests for new ledger paths

## Validation
- ruby -c Formula/learnings.rb
- ruby -c Formula/ledger.rb
- brew style Formula/learnings.rb Formula/ledger.rb
- release asset digests verified against tkersey/skills-zig releases