### PR TITLE
Update kotlin-debug-adapter to 0.4.4

### DIFF
--- a/Formula/kotlin-debug-adapter.rb
+++ b/Formula/kotlin-debug-adapter.rb
@@ -1,15 +1,9 @@
 class KotlinDebugAdapter < Formula
   desc "Kotlin/JVM debugging for any editor/IDE using the Debug Adapter Protocol"
   homepage "https://github.com/fwcd/kotlin-debug-adapter"
-  url "https://github.com/fwcd/kotlin-debug-adapter/archive/refs/tags/0.4.3.tar.gz"
-  sha256 "9ad4db7e8877ed73d0b14c682f8bb8c4aed62918e3d936f0eb368052e2de2a8d"
+  url "https://github.com/fwcd/kotlin-debug-adapter/archive/refs/tags/0.4.4.tar.gz"
+  sha256 "67158aa0bb8b0e00990895a53193c44aee9291828fe7c426df631975299cdae6"
   license "MIT"
-
-  bottle do
-    root_url "https://github.com/tkersey/homebrew-tap/releases/download/kotlin-debug-adapter-0.4.3"
-    sha256 cellar: :any_skip_relocation, big_sur:      "a6ff3a918dbcb0f128e0003063f3e1e9dccb5c26e965c563112921385308ea1a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "1bf9dfc572ce0eba73a76067d9fba26a7320242260cec797adca691464618e87"
-  end
 
   depends_on "gradle" => :build
   depends_on "openjdk"


### PR DESCRIPTION
## Summary
- update kotlin-debug-adapter formula to upstream 0.4.4
- refresh source tarball sha256
- remove stale 0.4.3 bottle metadata

## Validation
- brew style Formula/kotlin-debug-adapter.rb
- ruby -c Formula/kotlin-debug-adapter.rb
- curl 0.4.4 source tarball | shasum -a 256

## Notes
- Path-based brew audit/fetch is disabled for this non-active workspace tap checkout; CI and post-merge named formula checks bind to the active tap.