### PR TITLE
Update CLI formula releases

### DIFF
--- a/Formula/cas.rb
+++ b/Formula/cas.rb
@@ -1,14 +1,14 @@
 class Cas < Formula
   desc "Zig CLI helpers for Codex app-server orchestration"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.2.70"
+  version "0.2.72"
 
   if OS.mac?
     url "https://github.com/tkersey/skills-zig/releases/download/cas-v#{version}/cas-v#{version}-darwin-arm64.tar.gz"
-    sha256 "574dcb36f63209f1f7e2624882957b8ef23c0f4f90381a49abf244361226db7a"
+    sha256 "dc69cb97d5263ea7defd57f090539e3824030a11373d1d5a665308b632647361"
   else
     url "https://github.com/tkersey/skills-zig/releases/download/cas-v#{version}/cas-v#{version}-linux-x86_64.tar.gz"
-    sha256 "b430df7f856f44bf7b3b96e5131cf3bfacfaaed6859b78e39869caf2ad221e49"
+    sha256 "42e0c0d9fe7b5036b5c926aaa239bb5ac921dfa274fb5f7d061d6caafb21e867"
   end
 
   on_macos do

--- a/Formula/ledger.rb
+++ b/Formula/ledger.rb
@@ -1,15 +1,15 @@
 class Ledger < Formula
   desc "Zig CLI for repo-local durable source-memory ledgers"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.3.4"
+  version "0.3.5"
   license "MIT"
 
   if OS.mac?
     url "https://github.com/tkersey/skills-zig/releases/download/ledger-v#{version}/ledger-v#{version}-darwin-arm64.tar.gz"
-    sha256 "32787e82df539939709a761a451e03f2ad703b502f4538257a63032a986d8984"
+    sha256 "ab78116670b2da9c41b60c22a8fbe99cd290fabdbe7e4297eb3603b2a878e52c"
   else
     url "https://github.com/tkersey/skills-zig/releases/download/ledger-v#{version}/ledger-v#{version}-linux-x86_64.tar.gz"
-    sha256 "7ae7a746db4e2e7a94823a52d530626d8752f4f4e60b2fc4528d213aba98f0c0"
+    sha256 "4679613e16e568c32c9fbc5564448bdbb6bdd43df0c087ae623b02d02ae946d0"
   end
 
   on_macos do

--- a/Formula/memory-note.rb
+++ b/Formula/memory-note.rb
@@ -1,15 +1,15 @@
 class MemoryNote < Formula
   desc "Safe append-only custom Codex memory-source note writer"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.1.7"
+  version "0.1.8"
   license "MIT"
 
   if OS.mac?
     url "https://github.com/tkersey/skills-zig/releases/download/memory-note-v#{version}/memory-note-v#{version}-darwin-arm64.tar.gz"
-    sha256 "c5298b9319f1d3a1235c4ce057102c3aee184586f3fc84e2fd9ea6922f752245"
+    sha256 "c8d31cf1030fe24f63c117c136378781ec8044827965785eae28aa3670d460f0"
   else
     url "https://github.com/tkersey/skills-zig/releases/download/memory-note-v#{version}/memory-note-v#{version}-linux-x86_64.tar.gz"
-    sha256 "0e78d9317d62717e755c6f80efc473d2c536e129b6211d775f28586a852170f9"
+    sha256 "2aebd4851ede85d3ade3a1a7e37aa9c6ad7a0c9f9d47159a1ab3611247a94218"
   end
 
   on_macos do


### PR DESCRIPTION
Updates the Homebrew formulas for the latest released skills-zig CLI artifacts.\n\n- cas 0.2.72\n- ledger 0.3.5\n- memory-note 0.1.8\n\nLocal checks:\n- ruby -c Formula/cas.rb\n- ruby -c Formula/ledger.rb\n- ruby -c Formula/memory-note.rb