### PR TITLE
Update cas to 0.2.77

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,8 +33,20 @@ jobs:
 
       - run: brew test-bot --only-tap-syntax
 
-      - run: brew test-bot --only-formulae
+      - name: Test formulae
+        id: formulae
+        run: brew test-bot --only-formulae
         if: github.event_name == 'pull_request'
+
+      - name: Reject skipped or failed formulae
+        if: always() && github.event_name == 'pull_request'
+        env:
+          SKIPPED_OR_FAILED_FORMULAE: ${{ steps.formulae.outputs.skipped_or_failed_formulae }}
+        run: |
+          if [ -n "${SKIPPED_OR_FAILED_FORMULAE}" ]; then
+            echo "::error::Skipped or failed formulae: ${SKIPPED_OR_FAILED_FORMULAE}"
+            exit 1
+          fi
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'

--- a/Formula/cas.rb
+++ b/Formula/cas.rb
@@ -1,14 +1,14 @@
 class Cas < Formula
   desc "Zig CLI helpers for Codex app-server orchestration"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.2.75"
+  version "0.2.77"
 
   if OS.mac?
     url "https://github.com/tkersey/skills-zig/releases/download/cas-v#{version}/cas-v#{version}-darwin-arm64.tar.gz"
-    sha256 "8a553cc1009903b09bcbabe72a9f4c7e905c2aa56cad29258f77fe6bd935b7fd"
+    sha256 "02805480faaa33bb5e4298e9cd1c752e7beb48c0cf996f9b53b581f47c88877d"
   else
     url "https://github.com/tkersey/skills-zig/releases/download/cas-v#{version}/cas-v#{version}-linux-x86_64.tar.gz"
-    sha256 "876bdbe8ef08838dcde5aa955bd2c16eb2ec95aeea755aecbd72444f3978faa2"
+    sha256 "8c1bcdb2009dddd802363cd20b9a81548f507784c592461a075445f9fc0117b0"
   end
 
   on_macos do
@@ -66,7 +66,7 @@ class Cas < Formula
     assert_match "--verdict-only", review_help
     assert_match "--multi-agent-mode", review_help
     assert_match "--workflow-binding-json", review_help
-    assert_match "Real review waits default to 1800000", review_help
+    assert_match "Real review waits default to 2700000", review_help
     assert_match "smoke/control waits default to 300000", review_help
     assert_match "--workflow-binding-json", shell_output("#{bin}/cas review_session --help 2>&1")
     capabilities = shell_output("#{bin}/cas capabilities --json")


### PR DESCRIPTION
## Summary

- Point `Formula/cas.rb` at the published `cas-v0.2.77` macOS arm64 and Linux x86_64 archives with their exact SHA-256 digests.
- Update the installed CLI contract to assert 45-minute real-review waits and 5-minute smoke/control waits.
- Port only PR #21's fail-closed `skipped_or_failed_formulae` gate so TestBot cannot silently pass a skipped or failed formula.

## Boundary

This preserves the existing archive → formula → installed executable boundary. The formula name, supported platform branches, and sibling executable mapping remain unchanged.

## Validation

- `ruby -c Formula/cas.rb`
- `actionlint .github/workflows/tests.yml`
- `git diff --check`
- Exact workflow comparison with PR #21's fail-closed gate
- Downloaded release checksum verification:
  - macOS arm64: `02805480faaa33bb5e4298e9cd1c752e7beb48c0cf996f9b53b581f47c88877d`
  - Linux x86_64: `8c1bcdb2009dddd802363cd20b9a81548f507784c592461a075445f9fc0117b0`
- Cross-platform archive inventory and required sibling-binary checks
- macOS release binary help and capability assertions, including `2700000`/`300000` wait defaults

The macOS and Linux TestBot jobs remain the authoritative named-formula install and test proof.
