### PR TITLE
Update Seq, CAS, and Ledger releases

### DIFF
--- a/Formula/cas.rb
+++ b/Formula/cas.rb
@@ -1,14 +1,14 @@
 class Cas < Formula
   desc "Zig CLI helpers for Codex app-server orchestration"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.2.79"
+  version "0.2.80"
 
   if OS.mac?
     url "https://github.com/tkersey/skills-zig/releases/download/cas-v#{version}/cas-v#{version}-darwin-arm64.tar.gz"
-    sha256 "7f4cb241786a00946d8df19ed22d6c4b6fa3e125dcaec07d47ed68adeccb4892"
+    sha256 "03e32050c758743bdb0e9e01cb45ab011414c3ed25ec49d635e9466d9c0fa2db"
   else
     url "https://github.com/tkersey/skills-zig/releases/download/cas-v#{version}/cas-v#{version}-linux-x86_64.tar.gz"
-    sha256 "496d6517e0400b81d98fc24a2795f2c444003ed726468206a6c527f002ce5740"
+    sha256 "a4d37a64e90d8c29a050a04ae6af798a741ebfa05dfa50c975deacd39c50ed7d"
   end
 
   on_macos do

--- a/Formula/ledger.rb
+++ b/Formula/ledger.rb
@@ -1,15 +1,15 @@
 class Ledger < Formula
   desc "CLI for repo-local ledgers, plan addresses, and artifact validation"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.10.2"
+  version "0.10.3"
   license "MIT"
 
   if OS.mac?
     url "https://github.com/tkersey/skills-zig/releases/download/ledger-v#{version}/ledger-v#{version}-darwin-arm64.tar.gz"
-    sha256 "3092d97aafe0491f9fab5da825a5deec6bf6d276a2f0750077cdb213135284b8"
+    sha256 "d28a61b03f5a75daf55af6e8b2833a974328d945c2e9c22be4b77908240fc630"
   else
     url "https://github.com/tkersey/skills-zig/releases/download/ledger-v#{version}/ledger-v#{version}-linux-x86_64.tar.gz"
-    sha256 "5808761dca3efa7d4a11009c4758a391973787af16adcd7d45204532ebfcd9a4"
+    sha256 "7c394d20b1bc964986123767caf665a8285a479c9440403ef0021273d0e8eead"
   end
 
   on_macos do

--- a/Formula/seq.rb
+++ b/Formula/seq.rb
@@ -1,17 +1,17 @@
 class Seq < Formula
   desc "Zig CLI for mining Codex session and memory artifacts"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.3.49"
+  version "0.3.50"
   license "MIT"
 
   if OS.mac?
     depends_on arch: :arm64
     url "https://github.com/tkersey/skills-zig/releases/download/seq-v#{version}/seq-v#{version}-darwin-arm64.tar.gz"
-    sha256 "df72ffc853f9bcd7e7cad31d21ef662045f4ac56982990e8ce01d03159c51a94"
+    sha256 "f45a11792ef693bf0fff3f9a10e9e0ee57a26db704781e983d783f3fd404aa13"
   else
     depends_on arch: :x86_64
     url "https://github.com/tkersey/skills-zig/releases/download/seq-v#{version}/seq-v#{version}-linux-x86_64.tar.gz"
-    sha256 "8717314750f54be114ac95eb34c6c56c2dfabe798034236d81c7e739476f7daa"
+    sha256 "7a0ff3e115dffb0dd7251b53402136b13a86b423478c5d60f6ed2107c79c2941"
   end
 
   def install


### PR DESCRIPTION
## Summary

- publish Seq 0.3.50
- publish CAS 0.2.80
- publish Ledger 0.10.3
- bind each formula to the exact published macOS and generic release checksums

## Validation

- all three release tags resolve to skills-zig merge 1f52c76b874ce85684a6a13114e23467e5d5f74a
- release metadata and formula checksums agree for all six assets
- git diff --check
- ruby -c Formula/seq.rb
- ruby -c Formula/cas.rb
- ruby -c Formula/ledger.rb
- native brew test-bot matrix required before merge