### PR TITLE
Update Seq and Ledger for native receipts

### DIFF
--- a/Formula/ledger.rb
+++ b/Formula/ledger.rb
@@ -1,15 +1,17 @@
 class Ledger < Formula
   desc "CLI for repo-local ledgers, plan addresses, and artifact validation"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.10.3"
+  version "0.10.4"
   license "MIT"
+
+  depends_on "tkersey/tap/seq"
 
   if OS.mac?
     url "https://github.com/tkersey/skills-zig/releases/download/ledger-v#{version}/ledger-v#{version}-darwin-arm64.tar.gz"
-    sha256 "d28a61b03f5a75daf55af6e8b2833a974328d945c2e9c22be4b77908240fc630"
+    sha256 "5e4039a9a852783dd02718b9b5b53f98800225f665dd35fe7e53e8452d73b95d"
   else
     url "https://github.com/tkersey/skills-zig/releases/download/ledger-v#{version}/ledger-v#{version}-linux-x86_64.tar.gz"
-    sha256 "7c394d20b1bc964986123767caf665a8285a479c9440403ef0021273d0e8eead"
+    sha256 "55c902630224cd5e18c16b9cdd41f39f4551bd66bf4241ecaf247da9f964d986"
   end
 
   on_macos do
@@ -191,6 +193,7 @@ class Ledger < Formula
     assert_match "create", universalist_help
     assert_match "latest", universalist_help
     assert_match "path", universalist_help
+    assert_match "emit", universalist_help
 
     system "git", "init", "-q"
     if OS.mac?
@@ -207,6 +210,16 @@ class Ledger < Formula
     end
     (testpath/".gitignore").write ".ledger/\n"
     (testpath/"universalist-plan.md").write "# Universalist Plan\n\n## Status: planned\n"
+    skill_root = testpath/"universalist-skill"
+    (skill_root/"references").mkpath
+    (skill_root/"package.json").write "{\"version\":\"16.0.4\"}\n"
+    (skill_root/"references/decision-contract.json").write <<~JSON
+      {"skill_decision_contract":{"contract_version":"SKDC-v1","skill":{"name":"universalist","kind":"mixed","source_fingerprint":"tap-v1"},"triggers":[{"trigger_id":"UNI-TAP","description":"tap trigger","cue_literals":["tap"],"cue_regexes":[],"exclusions":[]}],"routes":[{"route_id":"UNI-ORDINARY","description":"tap route","aliases":[],"terminal":false},{"route_id":"UNI-PRESERVE","description":"tap alternative","aliases":[],"terminal":true}],"clauses":[{"clause_id":"UNI-TAP-001","trigger_refs":["UNI-TAP"],"expected_routes":["UNI-ORDINARY","UNI-PRESERVE"],"prohibited_routes":[],"required_artifacts":["receipt"],"success_signals":[],"failure_signals":[],"rationale":"tap coverage"}],"instrumentation":{"decision_receipt":"required","rationale":"tap coverage"}}}
+    JSON
+    system "git", "config", "user.name", "Homebrew Test"
+    system "git", "config", "user.email", "homebrew-test@example.invalid"
+    system "git", "add", ".gitignore", "universalist-plan.md", "universalist-skill"
+    system "git", "commit", "-q", "-m", "Add Universalist fixtures"
     first_plan = shell_output(
       "#{bin}/ledger create --source universalist --repo #{testpath} --template #{testpath}/universalist-plan.md",
     )
@@ -229,6 +242,19 @@ class Ledger < Formula
     assert_equal first_path, shell_output(
       "#{bin}/ledger path --source universalist --repo #{testpath} --id #{first_id}",
     ).strip
+
+    receipt = shell_output(
+      "#{bin}/ledger emit --source universalist " \
+      "--plan #{first_path} --contract #{skill_root}/references/decision-contract.json " \
+      "--trigger-ref UNI-TAP --clause-ref UNI-TAP-001 " \
+      "--question tap-seam --selected-route UNI-ORDINARY " \
+      "--rejected-route UNI-PRESERVE --expected-outcome tap-outcome " \
+      "--disposition changed --construction tap-adapter --law tap-law " \
+      "--falsifier tap-falsifier --advanced-mechanics none " \
+      "--evidence-ref tap:formula --write-plan",
+    )
+    assert_match '"selected_route":"UNI-ORDINARY"', receipt
+    assert_match '"skill_decision_receipt"', File.read(first_path)
 
     system bin/"ledger", "init"
     assert_path_exists testpath/".ledger/negative-ledger/events.jsonl"

--- a/Formula/ledger.rb
+++ b/Formula/ledger.rb
@@ -189,7 +189,7 @@ class Ledger < Formula
     end
 
     universalist_help = shell_output("#{bin}/ledger --source universalist --help")
-    assert_match "collision-safe Universalist plan artifacts", universalist_help
+    assert_match "Allocate, resolve, and emit receipts for Universalist plan artifacts", universalist_help
     assert_match "create", universalist_help
     assert_match "latest", universalist_help
     assert_match "path", universalist_help

--- a/Formula/seq.rb
+++ b/Formula/seq.rb
@@ -1,17 +1,17 @@
 class Seq < Formula
   desc "Zig CLI for mining Codex session and memory artifacts"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.3.50"
+  version "0.3.51"
   license "MIT"
 
   if OS.mac?
     depends_on arch: :arm64
     url "https://github.com/tkersey/skills-zig/releases/download/seq-v#{version}/seq-v#{version}-darwin-arm64.tar.gz"
-    sha256 "f45a11792ef693bf0fff3f9a10e9e0ee57a26db704781e983d783f3fd404aa13"
+    sha256 "0bc319b1abf2cf3a2f6372e7533401c6ae701b5fcffcf561e3d23805026f3c0d"
   else
     depends_on arch: :x86_64
     url "https://github.com/tkersey/skills-zig/releases/download/seq-v#{version}/seq-v#{version}-linux-x86_64.tar.gz"
-    sha256 "7a0ff3e115dffb0dd7251b53402136b13a86b423478c5d60f6ed2107c79c2941"
+    sha256 "2578b4b20f401e5082b8768f86ac5f0cd78eb7a8c9505cc27eb36ec5379d994d"
   end
 
   def install
@@ -63,6 +63,7 @@ class Seq < Formula
     capabilities = shell_output("#{bin}/seq capabilities --format json")
     assert_match "\"actuation_hylo_audit_v1\": true", capabilities
     assert_match "\"skill_decision_receipt_contract_binding_v1\": true", capabilities
+    assert_match "\"skill_contract_receipt_binding_projection_v1\": true", capabilities
     assert_match "\"decision_capsule_v1\": true", capabilities
     assert_match "\"decision_anchor_v1\": true", capabilities
     assert_match "\"historical_decisions_dataset_v1\": true", capabilities
@@ -81,6 +82,16 @@ class Seq < Formula
     assert_match "\"c3_structured_closure_v1\": true", capabilities
     assert_match "\"execution_policy_audit_v1\": true", capabilities
     assert_match "\"policy_transition_dataset_v1\": true", capabilities
+
+    (testpath/"receipt-contract.json").write <<~JSON
+      {"skill_decision_contract":{"contract_version":"SKDC-v1","skill":{"name":"tap-skill","kind":"decision","source_fingerprint":"tap-v1"},"triggers":[{"trigger_id":"T1","description":"tap trigger","cue_literals":["tap"],"cue_regexes":[],"exclusions":[]}],"routes":[{"route_id":"R1","description":"tap route","aliases":[],"terminal":true}],"clauses":[{"clause_id":"C1","trigger_refs":["T1"],"expected_routes":["R1"],"prohibited_routes":[],"required_artifacts":["receipt"],"success_signals":[],"failure_signals":[],"rationale":"tap coverage"}],"instrumentation":{"decision_receipt":"required","rationale":"tap coverage"}}}
+    JSON
+    receipt_projection = shell_output(
+      "#{bin}/seq skill-contract validate --file #{testpath}/receipt-contract.json --format json",
+    )
+    assert_match '"valid": true', receipt_projection
+    assert_match '"skill_kind": "decision"', receipt_projection
+    assert_match '"clause_routes": [{"clause_id": "C1"', receipt_projection
     if OS.mac?
       assert_match "\"hctp_source_selection_v1\": true", capabilities
       assert_match "\"hctp_independence_clusters_v1\": true", capabilities


### PR DESCRIPTION
## Summary

- Update Seq to 0.3.51 and Ledger to 0.10.4 using the published Darwin and Linux archive digests.
- Declare the compatible tap Seq formula as a Ledger runtime dependency.
- Exercise Seq's SKDC-v1 receipt-binding projection and Ledger's end-to-end Universalist receipt append in formula tests.

## Release proof

- `seq-v0.3.51` and `ledger-v0.10.4` both point to skills-zig merge commit `f087c11`.
- Each release contains exactly one Darwin arm64 archive and one Linux x86_64 archive.
- Freshly downloaded archives reproduce all four SHA-256 values recorded in the formulas.

## Local validation

- `git diff --check`
- `ruby -c Formula/seq.rb`
- `ruby -c Formula/ledger.rb`
- `brew style Formula/seq.rb Formula/ledger.rb`

The PR's macOS and Linux `brew test-bot` jobs own pre-merge install/test proof. After merge, tap-qualified local audit, upgrade, test, and installed-version checks will close the publication boundary.
