### PR TITLE
Release Hylo-free CLI surfaces

### DIFF
--- a/Formula/cas.rb
+++ b/Formula/cas.rb
@@ -1,14 +1,14 @@
 class Cas < Formula
   desc "Zig CLI helpers for Codex app-server orchestration"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.2.94"
+  version "0.3.0"
 
   if OS.mac?
     url "https://github.com/tkersey/skills-zig/releases/download/cas-v#{version}/cas-v#{version}-darwin-arm64.tar.gz"
-    sha256 "6114ed6d7172c29d933aea7a6e8b7373be72173156543ce5d2e2fb8ff9d00336"
+    sha256 "5c4b5274378c200eeaffd559356f10e7e05402877fa95512b95ca332cab8627b"
   else
     url "https://github.com/tkersey/skills-zig/releases/download/cas-v#{version}/cas-v#{version}-linux-x86_64.tar.gz"
-    sha256 "17061e171df01b625cac996844aaaa7f84a880e1d6301f3631234e4ab3c5effd"
+    sha256 "17f76790877b441109e24da0b2447f81e10679e44c44532f56c6f353b5acc223"
   end
 
   on_macos do
@@ -29,7 +29,6 @@ class Cas < Formula
     bin.install "cas-review-session" => "cas_review_session"
     bin.install "cas-session-inquiry" => "cas_session_inquiry"
     bin.install "cas-perf-budget-governor"
-    bin.install "cas_trial" if OS.mac?
   end
 
   test do
@@ -74,35 +73,6 @@ class Cas < Formula
     assert_match "\"cas_rer_opaque_request_binding_v1\": true", capabilities
     assert_match "\"cas_review_scoped_instructions_v1\": true", capabilities
     assert_match "\"cas_codex_0145_structured_review_v4\": true", capabilities
-
-    if OS.mac?
-      assert_path_exists bin/"cas_trial"
-      assert_match version.to_s, shell_output("#{bin}/cas_trial --version")
-      assert_match "trial", cas_help
-      assert_match "\"hylo_trial_runner_v1\": true", capabilities
-      assert_match "\"hylo_fd_lane_lease_v1\": true", capabilities
-      assert_match "\"hylo_signed_run_receipt_v1\": true", capabilities
-
-      trial_help = shell_output("#{bin}/cas trial --help 2>&1")
-      assert_match "One-claim HCTP lane runner", trial_help
-      assert_match "preflight", trial_help
-      assert_match "compile-replay", trial_help
-      assert_match "run", trial_help
-      assert_match "status", trial_help
-      assert_match "cleanup", trial_help
-      assert_match "key-info", trial_help
-
-      direct_trial_help = shell_output("#{bin}/cas_trial --help 2>&1")
-      assert_match "One-claim HCTP lane runner", direct_trial_help
-
-      invalid_trial = testpath/"invalid-trial.json"
-      invalid_trial.write "{}\n"
-      preflight = shell_output(
-        "#{bin}/cas trial preflight --trial #{invalid_trial} --lane-id tap-lane --json 2>&1",
-        1,
-      )
-      assert_match "MissingField", preflight
-    end
 
     inquiry_help = shell_output("#{bin}/cas_session_inquiry --help 2>&1")
     assert_match "cas_session_inquiry", inquiry_help

--- a/Formula/ledger.rb
+++ b/Formula/ledger.rb
@@ -1,17 +1,17 @@
 class Ledger < Formula
   desc "CLI for repo-local ledgers, plan addresses, and artifact validation"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.11.7"
+  version "0.12.0"
   license "MIT"
 
   depends_on "tkersey/tap/seq"
 
   if OS.mac?
     url "https://github.com/tkersey/skills-zig/releases/download/ledger-v#{version}/ledger-v#{version}-darwin-arm64.tar.gz"
-    sha256 "f3b5e726badc18d227a2d3f73421af2cf247eddd0a336a37c646b39a71e96ef0"
+    sha256 "1d333071901cac8b2523adb66c8978a479d15e49702425e6b8fd750597eee8ce"
   else
     url "https://github.com/tkersey/skills-zig/releases/download/ledger-v#{version}/ledger-v#{version}-linux-x86_64.tar.gz"
-    sha256 "55428ed9f37b6b806a287e810b7695947c83e10cfe304d62f1d72d6b06d18f32"
+    sha256 "a1aff63fbe2da34814b24b8c6ea2c58524f4e4533ebfda23ff78e786886b10cd"
   end
 
   on_macos do
@@ -48,17 +48,6 @@ class Ledger < Formula
     assert_match "plan-source-contract", validate_help
     assert_match "policy-synthesis-receipt", validate_help
     assert_match "source-memory-checkpoint", validate_help
-    assert_match "hylo-replay-episode", validate_help
-    assert_match "hylo-runner-input", validate_help
-    assert_match "hylo-stimulus", validate_help
-    assert_match "hylo-target-bundle", validate_help
-    assert_match "hylo-world-snapshot", validate_help
-    assert_match "hylo-world-availability-receipt", validate_help
-    assert_match "hylo-runtime-contract", validate_help
-    assert_match "hylo-counterfactual-cut-receipt", validate_help
-    assert_match "hylo-redaction-receipt", validate_help
-    assert_match "hylo-custody-manifest", validate_help
-    assert_match "hylo-trial", validate_help
     assert_match "never reads or writes .ledger", validate_help
 
     learning_export_help = shell_output("#{bin}/ledger export --source learnings --help")
@@ -72,16 +61,6 @@ class Ledger < Formula
     negative_doctor = shell_output("#{bin}/ledger doctor --source negative-ledger")
     assert_match '"ok":true', negative_doctor
     assert_match '"records":0', negative_doctor
-
-    (testpath/"malformed-hylo-episode.json").write "{}\n"
-    hylo_validation = shell_output(
-      "#{bin}/ledger validate hylo-replay-episode --input #{testpath}/malformed-hylo-episode.json",
-      2,
-    )
-    assert_match '"contract":"hylo-replay-episode"', hylo_validation
-    assert_match '"verdict":"blocked"', hylo_validation
-    assert_match '"authority_granted":false', hylo_validation
-    assert_match '"storage_mutated":false', hylo_validation
 
     (testpath/"plan-source-contract.json").write <<~JSON
       {
@@ -137,16 +116,6 @@ class Ledger < Formula
     assert_match "project", actuation_help
     assert_match "--review-contract FILE|-", actuation_help
 
-    if OS.mac?
-      hylo_help = shell_output("#{bin}/ledger --source hylo --help")
-      assert_match "portable replay-campaign validation", hylo_help
-      assert_match "validate-campaign", hylo_help
-      assert_match "snapshot-target", hylo_help
-      assert_match "progress", hylo_help
-      assert_match "frontier", hylo_help
-      assert_match "next-experiment", hylo_help
-    end
-
     universalist_help = shell_output("#{bin}/ledger --source universalist --help")
     assert_match "Allocate, resolve, and emit receipts for Universalist plan artifacts", universalist_help
     assert_match "create", universalist_help
@@ -165,18 +134,6 @@ class Ledger < Formula
     )
     assert_match ".ledger/actuation/tap-goal/evidence.jsonl", actuation_path
 
-    if OS.mac?
-      frontier = shell_output(
-        "#{bin}/ledger --source hylo frontier --campaign-id tap-missing --format json 2>&1",
-        2,
-      )
-      assert_match '"error":"CampaignMissing"', frontier
-      next_experiment = shell_output(
-        "#{bin}/ledger --source hylo next-experiment --campaign-id tap-missing --format json 2>&1",
-        2,
-      )
-      assert_match '"error":"CampaignMissing"', next_experiment
-    end
     (testpath/".gitignore").write ".ledger/\n"
     (testpath/"universalist-plan.md").write "# Universalist Plan\n\n## Status: planned\n"
     skill_root = testpath/"universalist-skill"

--- a/Formula/seq.rb
+++ b/Formula/seq.rb
@@ -1,17 +1,17 @@
 class Seq < Formula
   desc "Zig CLI for mining Codex session and memory artifacts"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.3.59"
+  version "0.4.0"
   license "MIT"
 
   if OS.mac?
     depends_on arch: :arm64
     url "https://github.com/tkersey/skills-zig/releases/download/seq-v#{version}/seq-v#{version}-darwin-arm64.tar.gz"
-    sha256 "2956d665443f7450cb295b44af44f274ac1cdff3121c9de8db311eee60dc2287"
+    sha256 "85b9928b695f4883ccd75b96cff177181b24b5079a4fe80166cef91db79d568c"
   else
     depends_on arch: :x86_64
     url "https://github.com/tkersey/skills-zig/releases/download/seq-v#{version}/seq-v#{version}-linux-x86_64.tar.gz"
-    sha256 "741262ae2337b37bf1d5daf15390d575e3bb2363b951bc36a00095b0f774c48c"
+    sha256 "ba112eca6a08b91502814151790e8ebcbd9b12a1b86a412baaed5aa92142c5b2"
   end
 
   def install
@@ -58,14 +58,8 @@ class Seq < Formula
     assert_match "find-session", help
     assert_match "dataset-schema", help
     assert_match "query", help
-    if OS.mac?
-      assert_match "hctp-source", help
-      assert_match "hylo-extract", help
-    end
-
     capabilities = shell_output("#{bin}/seq capabilities --format json")
     assert_match "\"streaming_session_scanner_v1\": true", capabilities
-    assert_match "\"actuation_hylo_audit_v1\": true", capabilities
     assert_match "\"actuation_artifact_kernel_audit_v1\": true", capabilities
     assert_match "\"skill_contract_v1\": true", capabilities
     assert_match "\"skill_decision_receipt_contract_binding_v1\": true", capabilities
@@ -99,30 +93,6 @@ class Seq < Formula
     assert_match '"valid": true', receipt_projection
     assert_match '"skill_kind": "decision"', receipt_projection
     assert_match '"clause_routes": [{"clause_id": "C1"', receipt_projection
-    if OS.mac?
-      assert_match "\"hctp_source_selection_v1\": true", capabilities
-      assert_match "\"hctp_independence_clusters_v1\": true", capabilities
-      assert_match "\"hctp_sealed_case_v1\": true", capabilities
-      assert_match "\"hctp_materializer_v1\": true", capabilities
-      assert_match "\"hylo_extract_v1\": true", capabilities
-
-      hctp_source_help = shell_output("#{bin}/seq hctp-source --help")
-      assert_match "compile", hctp_source_help
-      assert_match "validate", hctp_source_help
-      assert_match "govern", hctp_source_help
-      assert_match "materialize", hctp_source_help
-
-      hylo_extract_help = shell_output("#{bin}/seq hylo-extract --help")
-      assert_match "--root", hylo_extract_help
-      assert_match "--session-id", hylo_extract_help
-      assert_match "--turn-index", hylo_extract_help
-      assert_match "--target-skill", hylo_extract_help
-      assert_match "--target-root", hylo_extract_help
-      assert_match "--output-root", hylo_extract_help
-      assert_match "--sealed-root", hylo_extract_help
-      assert_match "--seal-key-output-fd", hylo_extract_help
-    end
-
     token_help = shell_output("#{bin}/seq token-usage --help")
     assert_match "--tz", token_help
     assert_match "--last", token_help
@@ -191,22 +161,7 @@ class Seq < Formula
     assert_match "--policy-root", execution_policy_help
 
     actuation_audit_help = shell_output("#{bin}/seq actuation-audit --help")
-    assert_match "summary|runs|slices|proof|compactions|decisions|hylo|kernel|report", actuation_audit_help
-
-    hylo_fixture = testpath/"hylo-resolve.jsonl"
-    hylo_fixture.write <<~JSONL
-      {"type":"session_meta","timestamp":"2026-07-02T13:10:00Z","payload":{"id":"resolve_without_review_fold","cwd":"#{testpath}","model":"gpt-5","git":{"branch":"feature/hylo","commit_hash":"head-resolve-no-fold"}}}
-      {"type":"event_msg","timestamp":"2026-07-02T13:10:01Z","payload":{"type":"task_started","turn_id":"t1"}}
-      {"type":"event_msg","timestamp":"2026-07-02T13:10:02Z","payload":{"type":"user_message","turn_id":"t1","message":"$actuating resolve without review-fold fixture."}}
-      {"type":"event_msg","timestamp":"2026-07-02T13:10:03Z","payload":{"type":"agent_message","turn_id":"t1","message":"$cas review\\nreview finding: accepted liability\\nagent_loop_scheme_receipt:\\n  receipt_version: ALSR-v1\\nactuation_hylomorphism:\\n  machine_version: HYL-v1\\nhylo_step_receipt:\\n  receipt_version: HSR-v1\\n  unfold:\\n    produced: work_node\\n  action:\\n    effect: edit\\n  fold:\\n    verdict: complete\\n    current_artifact_bound: yes\\n  stop_rule:\\n    success: done\\nATCG-v1:\\n  can_mark_goal_complete: yes"}}
-      {"type":"response_item","timestamp":"2026-07-02T13:10:04Z","payload":{"type":"function_call","name":"apply_patch","call_id":"patch-1","arguments":"*** Begin Patch\\n*** Update File: resolve_no_fold.txt\\n+bad\\n*** End Patch"}}
-      {"type":"response_item","timestamp":"2026-07-02T13:10:05Z","payload":{"type":"function_call_output","call_id":"patch-1","output":"Success. Updated the following files:\\nM resolve_no_fold.txt\\n"}}
-      {"type":"event_msg","timestamp":"2026-07-02T13:10:06Z","payload":{"type":"task_complete","turn_id":"t1","duration_ms":5000}}
-    JSONL
-    hylo_audit = shell_output("#{bin}/seq actuation-audit --path #{hylo_fixture} --mode hylo --format json")
-    assert_match "\"resolve_without_review_fold\":1", hylo_audit
-    refute_match "review_fix_without_review_fold", hylo_audit
-    refute_match "ship_without_terminal_publication_boundary", hylo_audit
+    assert_match "summary|runs|slices|proof|compactions|decisions|kernel|report", actuation_audit_help
 
     session_dir = testpath/"sessions/2026/05/13"
     session_dir.mkpath


### PR DESCRIPTION
## Summary

- publish Seq 0.4.0, CAS 0.3.0, and Ledger 0.12.0
- bind both platform archives to their release SHA256 values
- remove Hylo, HCTP, and CAS trial assertions from formula install/tests

## Release proof

- all six release build jobs and all three publish jobs passed
- formula Ruby syntax passes
- formula scan contains no Hylo, HCTP, CRF, or `cas_trial` references

## After merge

Run strict Homebrew audit/test and installed-version proof against the merged tap.