### PR TITLE
Release ledger 0.13.0 and seq 0.5.0

### DIFF
--- a/Formula/ledger.rb
+++ b/Formula/ledger.rb
@@ -1,17 +1,17 @@
 class Ledger < Formula
   desc "CLI for repo-local ledgers, plan addresses, and artifact validation"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.12.0"
+  version "0.13.0"
   license "MIT"
 
   depends_on "tkersey/tap/seq"
 
   if OS.mac?
     url "https://github.com/tkersey/skills-zig/releases/download/ledger-v#{version}/ledger-v#{version}-darwin-arm64.tar.gz"
-    sha256 "1d333071901cac8b2523adb66c8978a479d15e49702425e6b8fd750597eee8ce"
+    sha256 "392eccd15d676301b4963904dcfb6e9099ab8b57429e37d436e8f423faad94f8"
   else
     url "https://github.com/tkersey/skills-zig/releases/download/ledger-v#{version}/ledger-v#{version}-linux-x86_64.tar.gz"
-    sha256 "a1aff63fbe2da34814b24b8c6ea2c58524f4e4533ebfda23ff78e786886b10cd"
+    sha256 "6a30457f9a4ab230b94fd4a9b10cb93aab1189276fc513fb431015ee3a5da5f9"
   end
 
   on_macos do

--- a/Formula/seq.rb
+++ b/Formula/seq.rb
@@ -1,17 +1,17 @@
 class Seq < Formula
   desc "Zig CLI for mining Codex session and memory artifacts"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.4.1"
+  version "0.5.0"
   license "MIT"
 
   if OS.mac?
     depends_on arch: :arm64
     url "https://github.com/tkersey/skills-zig/releases/download/seq-v#{version}/seq-v#{version}-darwin-arm64.tar.gz"
-    sha256 "0bcd49545cd20d657844b6c2a5e12845ac89a76a5dd6dd9d839dc7ca215455e3"
+    sha256 "1e9271a8377ee529946d74691a00332bc6c99b0f7b351046372b53729c5e24a7"
   else
     depends_on arch: :x86_64
     url "https://github.com/tkersey/skills-zig/releases/download/seq-v#{version}/seq-v#{version}-linux-x86_64.tar.gz"
-    sha256 "30c8776a97afeab7dfd20b7d81f0f586d226b2e13a792e89f71728c9fd6fc691"
+    sha256 "68e6989706c52e91a52f53cef836980f258ab11ca16060441a247e6d30a96634"
   end
 
   def install


### PR DESCRIPTION
## Summary

- update `ledger` from 0.12.0 to 0.13.0
- update `seq` from 0.4.1 to 0.5.0
- bind both platform archives to the published GitHub release digests

## Verification

- `brew style Formula/ledger.rb Formula/seq.rb`
- release assets are published and non-draft
- formula SHA-256 values match GitHub release asset digests

## Release sources

- https://github.com/tkersey/skills-zig/releases/tag/ledger-v0.13.0
- https://github.com/tkersey/skills-zig/releases/tag/seq-v0.5.0
