### PR TITLE
Release Ledger 0.13.2 and Seq 0.5.2

### DIFF
--- a/Formula/ledger.rb
+++ b/Formula/ledger.rb
@@ -1,17 +1,17 @@
 class Ledger < Formula
   desc "CLI for repo-local ledgers, plan addresses, and artifact validation"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.13.1"
+  version "0.13.2"
   license "MIT"
 
   depends_on "tkersey/tap/seq"
 
   if OS.mac?
     url "https://github.com/tkersey/skills-zig/releases/download/ledger-v#{version}/ledger-v#{version}-darwin-arm64.tar.gz"
-    sha256 "e740bab4f518925e1f77d2d9123a91ee536e82ff7679096e3b6819bb79c080bc"
+    sha256 "be8664d75f49b251a302633d9e9dff4ed69a1021c3af4feab38e67b9ae998d2e"
   else
     url "https://github.com/tkersey/skills-zig/releases/download/ledger-v#{version}/ledger-v#{version}-linux-x86_64.tar.gz"
-    sha256 "8342de2042c5e53b11ae6974fc9bb59765e0a63e2f91524c6c9a09be7db65952"
+    sha256 "dcd1aed6db907535340a258967234947bf86489db822b2930da57ceeab57753d"
   end
 
   on_macos do

--- a/Formula/seq.rb
+++ b/Formula/seq.rb
@@ -1,17 +1,17 @@
 class Seq < Formula
   desc "Zig CLI for mining Codex session and memory artifacts"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.5.1"
+  version "0.5.2"
   license "MIT"
 
   if OS.mac?
     depends_on arch: :arm64
     url "https://github.com/tkersey/skills-zig/releases/download/seq-v#{version}/seq-v#{version}-darwin-arm64.tar.gz"
-    sha256 "d23a377b3ea29428c00f4d519f5c9ff4d3debfc27c0a9231aee7d104137e4379"
+    sha256 "1d301d8f43e11401f2e61716340a372edf241beff75e590612003420615f41bb"
   else
     depends_on arch: :x86_64
     url "https://github.com/tkersey/skills-zig/releases/download/seq-v#{version}/seq-v#{version}-linux-x86_64.tar.gz"
-    sha256 "38a1a856f49178973664cfcff7109a00c537dc83a4d28dacafa6e8637259ad16"
+    sha256 "c9cdd1045f42c80ff45d205faf77a52e1df0732f11302cd651fc52e9d0e93c39"
   end
 
   def install


### PR DESCRIPTION
## What changed

- update `ledger` to `0.13.2`
- update `seq` to `0.5.2`
- bind both macOS and Linux formulae to the published release SHA-256 digests

## Why

The shared actuation engine changed to preserve exact Construction lineage across Goal successors. Both shipped consumers therefore require new release identities.

## Verification

- both tags resolve to skills-zig commit `2084c7a4d7674e95f30e657c5d7d476ec9505f8d`
- downloaded release archives match all four formula checksums
- `ruby -c Formula/ledger.rb`
- `ruby -c Formula/seq.rb`
