### PR TITLE
Release Ledger 0.13.3 and Seq 0.5.3

### DIFF
--- a/Formula/ledger.rb
+++ b/Formula/ledger.rb
@@ -1,17 +1,17 @@
 class Ledger < Formula
   desc "CLI for repo-local ledgers, plan addresses, and artifact validation"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.13.2"
+  version "0.13.3"
   license "MIT"
 
   depends_on "tkersey/tap/seq"
 
   if OS.mac?
     url "https://github.com/tkersey/skills-zig/releases/download/ledger-v#{version}/ledger-v#{version}-darwin-arm64.tar.gz"
-    sha256 "be8664d75f49b251a302633d9e9dff4ed69a1021c3af4feab38e67b9ae998d2e"
+    sha256 "62a3c06d583eec4d7a03da2a9afe8a10317f3ef7036f6af25b273a66bd725e55"
   else
     url "https://github.com/tkersey/skills-zig/releases/download/ledger-v#{version}/ledger-v#{version}-linux-x86_64.tar.gz"
-    sha256 "dcd1aed6db907535340a258967234947bf86489db822b2930da57ceeab57753d"
+    sha256 "5a4ea0159697143df8c03717d5f9a7440f120173a281d8fd93e776a5d0a5aecd"
   end
 
   on_macos do

--- a/Formula/seq.rb
+++ b/Formula/seq.rb
@@ -1,17 +1,17 @@
 class Seq < Formula
   desc "Zig CLI for mining Codex session and memory artifacts"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.5.2"
+  version "0.5.3"
   license "MIT"
 
   if OS.mac?
     depends_on arch: :arm64
     url "https://github.com/tkersey/skills-zig/releases/download/seq-v#{version}/seq-v#{version}-darwin-arm64.tar.gz"
-    sha256 "1d301d8f43e11401f2e61716340a372edf241beff75e590612003420615f41bb"
+    sha256 "7e7dc4b1dcc22a2504fcaf460b1f95888158ec8bdaea4af8e8783ad71c05103a"
   else
     depends_on arch: :x86_64
     url "https://github.com/tkersey/skills-zig/releases/download/seq-v#{version}/seq-v#{version}-linux-x86_64.tar.gz"
-    sha256 "c9cdd1045f42c80ff45d205faf77a52e1df0732f11302cd651fc52e9d0e93c39"
+    sha256 "642bfbcd503d52390f9e66b3ce29383a30f46e1e8745bbf2700055c1ebf32dcc"
   end
 
   def install


### PR DESCRIPTION
## Summary

- update the Ledger formula to the official 0.13.3 release
- update the Seq formula to the official 0.5.3 release
- bind both platform variants to the published release-asset SHA-256 digests

## Verification

- downloaded all four official release assets and verified their SHA-256 digests
- `ruby -c Formula/ledger.rb`
- `ruby -c Formula/seq.rb`
- `brew test-bot --only-tap-syntax`
