### PR TITLE
Release Seq 0.5.4, CAS 0.3.2, and memory-note 0.1.11

### DIFF
--- a/Formula/cas.rb
+++ b/Formula/cas.rb
@@ -1,14 +1,14 @@
 class Cas < Formula
   desc "Zig CLI helpers for Codex app-server orchestration"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.3.1"
+  version "0.3.2"
 
   if OS.mac?
     url "https://github.com/tkersey/skills-zig/releases/download/cas-v#{version}/cas-v#{version}-darwin-arm64.tar.gz"
-    sha256 "c6a81fb578f2e7cd52100f08eac0d223bbe4474ba5d06f6660034924c3715019"
+    sha256 "ffcf44bd99e02b97f59bdb46848863fe677241759121614f5eeedaabc7934f54"
   else
     url "https://github.com/tkersey/skills-zig/releases/download/cas-v#{version}/cas-v#{version}-linux-x86_64.tar.gz"
-    sha256 "67994a64d2c325cde381a082fc8e80f79dfaf12679ca52dda9bce8148467cb2e"
+    sha256 "c98d145af3c09a7357b3d8439bc48da694edf0e87ace084a72d122f4d3f9decc"
   end
 
   on_macos do

--- a/Formula/memory-note.rb
+++ b/Formula/memory-note.rb
@@ -1,15 +1,15 @@
 class MemoryNote < Formula
   desc "Safe append-only custom Codex memory-source note writer"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.1.10"
+  version "0.1.11"
   license "MIT"
 
   if OS.mac?
     url "https://github.com/tkersey/skills-zig/releases/download/memory-note-v#{version}/memory-note-v#{version}-darwin-arm64.tar.gz"
-    sha256 "f10a3a970d915dfd12ee58e42cca16866780502f30083bd26a614fc97b0fc529"
+    sha256 "80171094e804cacac98ab60dd7111c0ced05ef9f80cd32ef216c2e4513b509e1"
   else
     url "https://github.com/tkersey/skills-zig/releases/download/memory-note-v#{version}/memory-note-v#{version}-linux-x86_64.tar.gz"
-    sha256 "2e4dccfd0c959a79919b8cdb5128d432383822289363daab2453e7504be57d59"
+    sha256 "31a79ff386bf323a59adf7540fe8cfca12fe4e4e460f2b854df1217da3f934c2"
   end
 
   on_macos do

--- a/Formula/seq.rb
+++ b/Formula/seq.rb
@@ -1,17 +1,17 @@
 class Seq < Formula
   desc "Zig CLI for mining Codex session and memory artifacts"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.5.3"
+  version "0.5.4"
   license "MIT"
 
   if OS.mac?
     depends_on arch: :arm64
     url "https://github.com/tkersey/skills-zig/releases/download/seq-v#{version}/seq-v#{version}-darwin-arm64.tar.gz"
-    sha256 "7e7dc4b1dcc22a2504fcaf460b1f95888158ec8bdaea4af8e8783ad71c05103a"
+    sha256 "01bc3ae15e5a9c0f1e7baf8234c0ed7ba68bdc893bc60bb210429e41d1816a2f"
   else
     depends_on arch: :x86_64
     url "https://github.com/tkersey/skills-zig/releases/download/seq-v#{version}/seq-v#{version}-linux-x86_64.tar.gz"
-    sha256 "642bfbcd503d52390f9e66b3ce29383a30f46e1e8745bbf2700055c1ebf32dcc"
+    sha256 "6737e72230d00120b95e0e0affdbee54e59b7f2f06b7ffeb5d71e41559bc16a5"
   end
 
   def install
@@ -53,6 +53,7 @@ class Seq < Formula
     assert_match "skill-contract", help
     assert_match "skill-decision-receipt", help
     assert_match "decision-capsule", help
+    assert_match "execution-policy-compile", help
     assert_match "execution-policy-audit", help
     assert_match "policy-calibration", help
     assert_match "find-session", help
@@ -81,6 +82,7 @@ class Seq < Formula
     assert_match "\"internal_context_not_success_v1\": true", capabilities
     assert_match "\"source_governance_projection_v1\": true", capabilities
     assert_match "\"c3_structured_closure_v1\": true", capabilities
+    assert_match "\"execution_policy_compiler_contract_v1\": true", capabilities
     assert_match "\"execution_policy_audit_v1\": true", capabilities
     assert_match "\"policy_transition_dataset_v1\": true", capabilities
 
@@ -159,6 +161,10 @@ class Seq < Formula
     execution_policy_help = shell_output("#{bin}/seq execution-policy-audit --help")
     assert_match "summary|runs|policies|transitions|calibration|regret|proof|report", execution_policy_help
     assert_match "--policy-root", execution_policy_help
+
+    execution_policy_compile_help = shell_output("#{bin}/seq execution-policy-compile --help")
+    assert_match "--file", execution_policy_compile_help
+    assert_match "--format json", execution_policy_compile_help
 
     actuation_audit_help = shell_output("#{bin}/seq actuation-audit --help")
     assert_match "summary|runs|slices|proof|compactions|decisions|kernel|report", actuation_audit_help


### PR DESCRIPTION
## Summary

- update `seq` to `0.5.4`;
- update `cas` to `0.3.2`;
- update `memory-note` to `0.1.11`;
- bind each Darwin and Linux formula checksum to the corresponding published release asset;
- extend the Seq formula test to cover `execution-policy-compile` and `execution_policy_compiler_contract_v1`.

These releases contain the CLI changes merged in [tkersey/skills-zig#95](https://github.com/tkersey/skills-zig/pull/95).

## Release evidence

- [seq-v0.5.4](https://github.com/tkersey/skills-zig/releases/tag/seq-v0.5.4)
- [cas-v0.3.2](https://github.com/tkersey/skills-zig/releases/tag/cas-v0.3.2)
- [memory-note-v0.1.11](https://github.com/tkersey/skills-zig/releases/tag/memory-note-v0.1.11)

All three tags resolve to skills-zig commit `711ddc75408fdf25c98c26af839748c8128f78b2`. All six downloaded archives match the SHA256 values recorded in this change.

## Validation

- `ruby -c Formula/seq.rb`
- `ruby -c Formula/cas.rb`
- `ruby -c Formula/memory-note.rb`
- `brew style Formula/seq.rb Formula/cas.rb Formula/memory-note.rb`

Homebrew strict audit, formula tests, reinstall, and installed-version checks will run against the published tap state after merge.
