### PR TITLE
Release Seq and Ledger 1.0

### DIFF
--- a/Formula/cas.rb
+++ b/Formula/cas.rb
@@ -3,6 +3,8 @@ class Cas < Formula
   homepage "https://github.com/tkersey/skills-zig"
   version "0.3.4"
 
+  depends_on "tkersey/tap/ledger"
+
   if OS.mac?
     url "https://github.com/tkersey/skills-zig/releases/download/cas-v#{version}/cas-v#{version}-darwin-arm64.tar.gz"
     sha256 "2a693f270db087afda3d12c584bac89819bf1720991f7f2331bd1677163f11de"

--- a/Formula/cas.rb
+++ b/Formula/cas.rb
@@ -1,14 +1,14 @@
 class Cas < Formula
   desc "Zig CLI helpers for Codex app-server orchestration"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.3.2"
+  version "0.3.4"
 
   if OS.mac?
     url "https://github.com/tkersey/skills-zig/releases/download/cas-v#{version}/cas-v#{version}-darwin-arm64.tar.gz"
-    sha256 "ffcf44bd99e02b97f59bdb46848863fe677241759121614f5eeedaabc7934f54"
+    sha256 "2a693f270db087afda3d12c584bac89819bf1720991f7f2331bd1677163f11de"
   else
     url "https://github.com/tkersey/skills-zig/releases/download/cas-v#{version}/cas-v#{version}-linux-x86_64.tar.gz"
-    sha256 "c98d145af3c09a7357b3d8439bc48da694edf0e87ace084a72d122f4d3f9decc"
+    sha256 "023c208d659a153c648cbb48d7c98026e14f6168209b7b32c3afada02ed3dfcc"
   end
 
   on_macos do

--- a/Formula/ledger.rb
+++ b/Formula/ledger.rb
@@ -1,17 +1,15 @@
 class Ledger < Formula
-  desc "CLI for repo-local ledgers, plan addresses, and artifact validation"
+  desc "Native artifact validation and durable protocol runtime"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.13.3"
+  version "1.0.0"
   license "MIT"
-
-  depends_on "tkersey/tap/seq"
 
   if OS.mac?
     url "https://github.com/tkersey/skills-zig/releases/download/ledger-v#{version}/ledger-v#{version}-darwin-arm64.tar.gz"
-    sha256 "62a3c06d583eec4d7a03da2a9afe8a10317f3ef7036f6af25b273a66bd725e55"
+    sha256 "f55fee27fa5b6d0d409bd8dcd268404b8e1bd71f9a0d3033e863e86fc415190d"
   else
     url "https://github.com/tkersey/skills-zig/releases/download/ledger-v#{version}/ledger-v#{version}-linux-x86_64.tar.gz"
-    sha256 "5a4ea0159697143df8c03717d5f9a7440f120173a281d8fd93e776a5d0a5aecd"
+    sha256 "c2029a321b9ae925fb3c9834a1003cde5237dcc08dbf65b5b398e12a9e6c0236"
   end
 
   on_macos do
@@ -27,241 +25,48 @@ class Ledger < Formula
   end
 
   test do
-    version_output = shell_output("#{bin}/ledger --version")
-    assert_match version.to_s, version_output
+    assert_equal version.to_s, shell_output("#{bin}/ledger --version").strip
 
-    help = shell_output("#{bin}/ledger --help")
-    assert_match "Materialize, validate, record, and project workflow artifacts", help
-    assert_match "including Actuating evidence", help
-    assert_match "capture", help
-    assert_match "map", help
-    assert_match "migrate", help
-    assert_match "--source SOURCE", help
-    assert_match "recall", help
-    assert_match "status", help
-    assert_match "export", help
-    assert_match "lifecycle-transition proof JSON", help
-    assert_match "--route-family ID", help
-    assert_match "--proof-pattern ID", help
+    capabilities = JSON.parse(shell_output("#{bin}/ledger capabilities --format json"))
+    assert_equal "ledger-capabilities/v1", capabilities.fetch("schema")
+    assert_includes capabilities.fetch("artifact_abis"), "ledger-artifact-abi/v1"
+    assert_includes capabilities.fetch("storage_adapters"), "event-log"
 
-    validate_help = shell_output("#{bin}/ledger validate --help")
-    assert_match "plan-source-contract", validate_help
-    assert_match "policy-synthesis-receipt", validate_help
-    assert_match "source-memory-checkpoint", validate_help
-    assert_match "never reads or writes .ledger", validate_help
-
-    learning_export_help = shell_output("#{bin}/ledger export --source learnings --help")
-    assert_match "memory-note", learning_export_help
-    assert_match "Canonical learning id", learning_export_help
-
-    learning_show_help = shell_output("#{bin}/ledger show --source learnings --help")
-    assert_match "alias for export --format full", learning_show_help
-    assert_match "Canonical learning id", learning_show_help
-
-    (testpath/".ledger/negative-ledger").mkpath
-    negative_doctor = shell_output("#{bin}/ledger doctor --source negative-ledger")
-    assert_match '"ok":true', negative_doctor
-    assert_match '"records":0', negative_doctor
-
-    (testpath/"plan-source-contract.json").write <<~JSON
+    (testpath/"definition.json").write <<~JSON
       {
-        "plan_source_contract": {
-          "contract_version": "PSC-v1",
-          "source_owner": "spec-pipeline",
-          "spec_id": "tap-test",
-          "implementation_spec": {"ref": "tap-test"},
-          "decision_packet": {"ref": "tap-test"},
-          "proof_bar": {"command": "ledger --version"},
-          "target_branch": "main",
-          "do_not_execute_before": [],
-          "sgr_v2": {
-            "spec_governance_receipt": {
-              "receipt_version": "SGR-v2",
-              "mode": "full",
-              "status": "complete",
-              "lane": "spec_to_plan",
-              "gate": {
-                "plan_allowed": "yes",
-                "material_open_questions_remaining": "no"
-              },
-              "lint": {
-                "verdict": "pass",
-                "blocked_handoff": "no"
-              },
-              "execution_handoff": {
-                "ready_for_plan": "yes",
-                "next_owner": "$plan",
-                "do_not_execute_before": []
-              },
-              "auto_plan_handoff": {
-                "eligible": "yes",
-                "invocation": "same_turn_tail_call"
-              }
-            }
-          }
-        }
+        "schema":"ledger-artifact-definition/v1",
+        "id":"tap/record","owner":"tap",
+        "requires":{"abi":"ledger-artifact-abi/v1","operators":["enum","exact-object","scalar-type"]},
+        "parameters":{},
+        "inputs":{"record":{"codec":"json","max_bytes":1024}},
+        "canonicalization":{},
+        "shape":{"documents":{"record":{"object":"exact","fields":{
+          "id":{"scalar":"string"},"status":{"enum":["open","closed"]}
+        }}}},
+        "constraints":{"laws":[]},"identity":{},
+        "storage":{"kind":"pure"},"operations":{},"projections":{},
+        "bounds":{"max_input_bytes":1024,"max_store_bytes":1024,"max_records":1,
+          "max_output_bytes":1024,"max_diagnostics":8,"max_reducer_states":1}
       }
     JSON
-    validation = shell_output(
-      "#{bin}/ledger validate plan-source-contract --input #{testpath}/plan-source-contract.json",
-    )
-    assert_match '"verdict":"pass"', validation
-    assert_match '"authority_granted":false', validation
-    assert_match '"storage_mutated":false', validation
+    (testpath/"record.json").write %Q({"id":"record-1","status":"open"}\n)
 
-    actuation_help = shell_output("#{bin}/ledger --source actuation --help")
-    assert_match "Materialize Actuating artifacts", actuation_help
-    assert_match "append", actuation_help
-    assert_match "prepare", actuation_help
-    assert_match "state", actuation_help
-    assert_match "project", actuation_help
-    assert_match "--review-contract FILE|-", actuation_help
+    check_output = shell_output(
+      "#{bin}/ledger definition check --definition #{testpath}/definition.json --format json",
+    )
+    check = JSON.parse(check_output)
+    assert check.fetch("valid")
+    assert check.fetch("passive")
+    refute check.fetch("authority_granted")
 
-    system "git", "init", "-q"
-    universalist_help = shell_output("#{bin}/ledger --source universalist --help")
-    assert_match "Allocate, resolve, and emit receipts for Universalist plan artifacts", universalist_help
-    assert_match "create", universalist_help
-    assert_match "latest", universalist_help
-    assert_match "path", universalist_help
-    assert_match "emit", universalist_help
-
-    actuation_doctor = shell_output(
-      "#{bin}/ledger --source actuation --repo #{testpath} --goal tap-goal doctor",
+    result_output = shell_output(
+      "#{bin}/ledger validate --definition #{testpath}/definition.json " \
+      "--input record=#{testpath}/record.json --format json",
     )
-    assert_match '"ok":true', actuation_doctor
-    assert_match '"events":0', actuation_doctor
-    actuation_path = shell_output(
-      "#{bin}/ledger --source actuation --repo #{testpath} --goal tap-goal path",
-    )
-    assert_match ".ledger/actuation/tap-goal/evidence.jsonl", actuation_path
-
-    (testpath/".gitignore").write ".ledger/\n"
-    (testpath/"universalist-plan.md").write "# Universalist Plan\n\n## Status: planned\n"
-    skill_root = testpath/"universalist-skill"
-    (skill_root/"references").mkpath
-    (skill_root/"package.json").write "{\"version\":\"16.0.4\"}\n"
-    (skill_root/"references/decision-contract.json").write <<~JSON
-      {"skill_decision_contract":{"contract_version":"SKDC-v1","skill":{"name":"universalist","kind":"mixed","source_fingerprint":"tap-v1"},"triggers":[{"trigger_id":"UNI-TAP","description":"tap trigger","cue_literals":["tap"],"cue_regexes":[],"exclusions":[]}],"routes":[{"route_id":"UNI-ORDINARY","description":"tap route","aliases":[],"terminal":false},{"route_id":"UNI-PRESERVE","description":"tap alternative","aliases":[],"terminal":true}],"clauses":[{"clause_id":"UNI-TAP-001","trigger_refs":["UNI-TAP"],"expected_routes":["UNI-ORDINARY","UNI-PRESERVE"],"prohibited_routes":[],"required_artifacts":["receipt"],"success_signals":[],"failure_signals":[],"rationale":"tap coverage"}],"instrumentation":{"decision_receipt":"required","rationale":"tap coverage"}}}
-    JSON
-    system "git", "config", "user.name", "Homebrew Test"
-    system "git", "config", "user.email", "homebrew-test@example.invalid"
-    system "git", "add", ".gitignore", "universalist-plan.md", "universalist-skill"
-    system "git", "commit", "-q", "-m", "Add Universalist fixtures"
-    first_plan = shell_output(
-      "#{bin}/ledger create --source universalist --repo #{testpath} --template #{testpath}/universalist-plan.md",
-    )
-    second_plan = shell_output(
-      "#{bin}/ledger create --source universalist --repo #{testpath} --template #{testpath}/universalist-plan.md",
-    )
-    first_id = first_plan[/"plan_id":"([^"]+)"/, 1]
-    second_id = second_plan[/"plan_id":"([^"]+)"/, 1]
-    first_path = first_plan[/"path":"([^"]+)"/, 1]
-    second_path = second_plan[/"path":"([^"]+)"/, 1]
-    refute_equal first_id, second_id
-    refute_equal first_path, second_path
-    assert_equal (testpath/".ledger/universalist/plan-#{first_id}.md").to_s, first_path
-    assert_equal (testpath/".ledger/universalist/plan-#{second_id}.md").to_s, second_path
-    assert_path_exists first_path
-    assert_path_exists second_path
-    assert_equal second_path, shell_output(
-      "#{bin}/ledger latest --source universalist --repo #{testpath} --format path",
-    ).strip
-    assert_equal first_path, shell_output(
-      "#{bin}/ledger path --source universalist --repo #{testpath} --id #{first_id}",
-    ).strip
-
-    receipt = shell_output(
-      "#{bin}/ledger emit --source universalist " \
-      "--plan #{first_path} --contract #{skill_root}/references/decision-contract.json " \
-      "--trigger-ref UNI-TAP --clause-ref UNI-TAP-001 " \
-      "--question tap-seam --selected-route UNI-ORDINARY " \
-      "--rejected-route UNI-PRESERVE --expected-outcome tap-outcome " \
-      "--disposition changed --construction tap-adapter --law tap-law " \
-      "--falsifier tap-falsifier --advanced-mechanics none " \
-      "--evidence-ref tap:formula --write-plan",
-    )
-    assert_match '"selected_route":"UNI-ORDINARY"', receipt
-    assert_match '"skill_decision_receipt"', File.read(first_path)
-
-    system bin/"ledger", "init"
-    assert_path_exists testpath/".ledger/negative-ledger/events.jsonl"
-    assert_match "\"ok\":true", shell_output("#{bin}/ledger doctor")
-
-    capture_help = shell_output("#{bin}/ledger capture --source learnings --help 2>&1")
-    assert_match "repo-local learning-source API", capture_help
-
-    legacy_repo = testpath/"legacy-repo"
-    legacy_repo.mkpath
-    system "git", "-C", legacy_repo, "init", "-q"
-    (legacy_repo/".gitignore").write ".ledger/\n"
-    (legacy_repo/".learnings.jsonl").write <<~JSONL
-      {"id":"lrn-old-1","status":"do_more","learning":"Keep valid legacy records."}
-      {"id":"lrn-old-2","status":"do_more","fingerprint":"fp",
-      tags":["migration"]}
-      ags":["orphan"]}
-    JSONL
-    legacy_doctor = shell_output(
-      "cd #{legacy_repo} && #{bin}/ledger doctor --source learnings",
-      1,
-    )
-    assert_match '"status":"invalid"', legacy_doctor
-    assert_match '"repaired_records":1', legacy_doctor
-    assert_match '"invalid_records":1', legacy_doctor
-    migration = shell_output(
-      "cd #{legacy_repo} && #{bin}/ledger migrate --source learnings --mode copy --invalid-policy skip",
-    )
-    assert_match '"status":"migrated_with_skips"', migration
-    assert_match '"records":2', migration
-    assert_match '"repaired_records":1', migration
-    assert_match '"skipped_records":1', migration
-    assert_match '"legacy_left_in_place":true', migration
-    assert_path_exists legacy_repo/".learnings.jsonl"
-    assert_path_exists legacy_repo/".ledger/learnings/events.jsonl"
-    assert_match '"status":"current"', shell_output(
-      "cd #{legacy_repo} && #{bin}/ledger doctor --source learnings",
-    )
-
-    assert_match "synesthesia", shell_output("#{bin}/ledger --help")
-    assert_match "\"status\":\"missing\"", shell_output("#{bin}/ledger doctor --source synesthesia")
-
-    (testpath/"synesthesia.json").write <<~JSON
-      {"operation":"assert","authority":"explicit-user-endorsement","summary":"Endorse long corridor.","scope":{"kind":"task-family","repo":null,"paths":[]},"source_refs":[{"kind":"user","ref":"tap-test","summary":"User endorsed long corridor mapping."}],"related_ids":[],"supersedes_id":null,"payload":{"sensory_phrase":"long corridor","engineering_translation":"serialized waits","activation_boundary":"latency work","non_activation_boundary":"syntax","verification":"name the wait"}}
-    JSON
-    system bin/"ledger", "capture", "--source", "synesthesia",
-      "--kind", "mapping-endorsement", "--json", testpath/"synesthesia.json"
-    assert_path_exists testpath/".ledger/synesthesia/events.jsonl"
-    synesthesia_recent = shell_output("#{bin}/ledger recent --source synesthesia --limit 1")
-    assert_match "long corridor", synesthesia_recent
-    synesthesia_id = synesthesia_recent[/SYN-[^ ]+/]
-    assert_match "SYN-", synesthesia_id
-    synesthesia_export = shell_output(
-      "#{bin}/ledger export --source synesthesia --format memory-note --id #{synesthesia_id}",
-    )
-    assert_match "\"operation\":\"assert\"", synesthesia_export
-    refute_match "logical_kind", synesthesia_export
-
-    learning_capture = shell_output(
-      "#{bin}/ledger capture --source learnings --status do_more " \
-      "--learning \"When tap tests install ledger, use ledger capture --source learnings " \
-      "because formula tests catch regressions.\" " \
-      "--evidence \"command: brew test ledger writes .ledger/learnings/events.jsonl\" " \
-      "--application \"Keep ledger --source learnings covered in the formula test.\" " \
-      "--tag homebrew --allow-temp-path",
-    )
-    learning_id = learning_capture[/appended: id=(lrn-[^ ]+)/, 1]
-    refute_nil learning_id
-    assert_path_exists testpath/".ledger/learnings/events.jsonl"
-    recent = shell_output("#{bin}/ledger recent --source learnings --limit 1")
-    assert_match "tap tests install ledger", recent
-
-    learning_full = shell_output(
-      "#{bin}/ledger export --source learnings --id #{learning_id} --format full",
-    )
-    assert_equal learning_full, shell_output(
-      "#{bin}/ledger show --source learnings --id #{learning_id}",
-    )
-    assert_equal learning_full, shell_output(
-      "#{bin}/ledger --source learnings show --id #{learning_id}",
-    )
+    result = JSON.parse(result_output)
+    assert_equal "ledger-validation-result/v1", result.fetch("schema")
+    assert result.fetch("valid")
+    refute result.fetch("authority_granted")
+    refute result.fetch("storage_mutated")
   end
 end

--- a/Formula/memory-note.rb
+++ b/Formula/memory-note.rb
@@ -1,15 +1,15 @@
 class MemoryNote < Formula
   desc "Safe append-only custom Codex memory-source note writer"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.1.11"
+  version "0.1.12"
   license "MIT"
 
   if OS.mac?
     url "https://github.com/tkersey/skills-zig/releases/download/memory-note-v#{version}/memory-note-v#{version}-darwin-arm64.tar.gz"
-    sha256 "80171094e804cacac98ab60dd7111c0ced05ef9f80cd32ef216c2e4513b509e1"
+    sha256 "48407eaa0e155ff7399aeef39dfacb31914b3da78111f1e04ddf1d8eca8296c0"
   else
     url "https://github.com/tkersey/skills-zig/releases/download/memory-note-v#{version}/memory-note-v#{version}-linux-x86_64.tar.gz"
-    sha256 "31a79ff386bf323a59adf7540fe8cfca12fe4e4e460f2b854df1217da3f934c2"
+    sha256 "d4fd71f451e2a2be0b1a68d2497f31c6b29a88e4c080e6a080b175cfeb04d284"
   end
 
   on_macos do

--- a/Formula/seq.rb
+++ b/Formula/seq.rb
@@ -1,17 +1,17 @@
 class Seq < Formula
-  desc "Zig CLI for mining Codex session and memory artifacts"
+  desc "Native observation compiler for agent session evidence"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.5.4"
+  version "1.0.0"
   license "MIT"
 
   if OS.mac?
     depends_on arch: :arm64
     url "https://github.com/tkersey/skills-zig/releases/download/seq-v#{version}/seq-v#{version}-darwin-arm64.tar.gz"
-    sha256 "01bc3ae15e5a9c0f1e7baf8234c0ed7ba68bdc893bc60bb210429e41d1816a2f"
+    sha256 "a236cabe32334fa888fbae4456fd87b9ec8123ba4f016abf11f24649e6934667"
   else
     depends_on arch: :x86_64
     url "https://github.com/tkersey/skills-zig/releases/download/seq-v#{version}/seq-v#{version}-linux-x86_64.tar.gz"
-    sha256 "6737e72230d00120b95e0e0affdbee54e59b7f2f06b7ffeb5d71e41559bc16a5"
+    sha256 "4cae5649607173ead8cb9232060773e1ff7e274b78933cc728a378af1709d6f6"
   end
 
   def install
@@ -19,195 +19,50 @@ class Seq < Formula
   end
 
   test do
-    version_output = shell_output("#{bin}/seq --version")
-    assert_equal version.to_s, version_output.strip
+    assert_equal version.to_s, shell_output("#{bin}/seq --version").strip
 
-    help = shell_output("#{bin}/seq --help")
-    assert_match "skills-rank", help
-    assert_match "skill-success-rank", help
-    assert_match "skill-evidence", help
-    assert_match "skill-blocks", help
-    assert_match "artifact-search", help
-    assert_match "skill-audit", help
-    assert_match "tool-audit", help
-    assert_match "memory-inventory", help
-    assert_match "message-search", help
-    assert_match "workdir-report", help
-    assert_match "memory-provenance", help
-    assert_match "memory-map", help
-    assert_match "memory-history", help
-    assert_match "plan-search", help
-    assert_match "reply-latency", help
-    assert_match "workflow-audit", help
-    assert_match "message-audit", help
-    assert_match "skill-cohort", help
-    assert_match "tool-search", help
-    assert_match "memory-extension-audit", help
-    assert_match "token-window", help
-    assert_match "goal-audit", help
-    assert_match "adjudication-audit", help
-    assert_match "workflow-overlap", help
-    assert_match "resolve-churn-audit", help
-    assert_match "review-compiler-audit", help
-    assert_match "skill-decision-audit", help
-    assert_match "skill-contract", help
-    assert_match "skill-decision-receipt", help
-    assert_match "decision-capsule", help
-    assert_match "execution-policy-compile", help
-    assert_match "execution-policy-audit", help
-    assert_match "policy-calibration", help
-    assert_match "find-session", help
-    assert_match "dataset-schema", help
-    assert_match "query", help
-    capabilities = shell_output("#{bin}/seq capabilities --format json")
-    assert_match "\"streaming_session_scanner_v1\": true", capabilities
-    assert_match "\"actuation_artifact_kernel_audit_v1\": true", capabilities
-    assert_match "\"skill_contract_v1\": true", capabilities
-    assert_match "\"skill_decision_receipt_contract_binding_v1\": true", capabilities
-    assert_match "\"skill_contract_receipt_binding_projection_v1\": true", capabilities
-    assert_match "\"skill_decision_receipt_v1\": true", capabilities
-    assert_match "\"decision_capsule_v1\": true", capabilities
-    assert_match "\"decision_anchor_v1\": true", capabilities
-    assert_match "\"historical_decisions_dataset_v1\": true", capabilities
-    assert_match "\"dcp_validation_v1\": true", capabilities
-    assert_match "\"review_compiler_provenance_v1\": true", capabilities
-    assert_match "\"review_compiler_run_ledger_v1\": true", capabilities
-    assert_match "\"resolve_acceptance_contract_v2\": true", capabilities
-    assert_match "\"resolve_review_batch_v1\": true", capabilities
-    assert_match "\"resolve_review_aperture_v1\": true", capabilities
-    assert_match "\"resolve_counterexample_v1\": true", capabilities
-    assert_match "\"resolve_counterexample_basis_v2\": true", capabilities
-    assert_match "\"resolve_review_potential_v1\": true", capabilities
-    assert_match "\"resolve_intent_closed_audit_v1\": true", capabilities
-    assert_match "\"internal_context_not_success_v1\": true", capabilities
-    assert_match "\"source_governance_projection_v1\": true", capabilities
-    assert_match "\"c3_structured_closure_v1\": true", capabilities
-    assert_match "\"execution_policy_compiler_contract_v1\": true", capabilities
-    assert_match "\"execution_policy_audit_v1\": true", capabilities
-    assert_match "\"policy_transition_dataset_v1\": true", capabilities
+    capabilities = JSON.parse(shell_output("#{bin}/seq capabilities --format json"))
+    assert_equal "seq-capabilities/v1", capabilities.fetch("schema")
+    assert_includes capabilities.fetch("observation_abis"), "seq-observation-abi/v1"
+    assert_includes capabilities.fetch("source_adapters"), "immutable-relation-json/v1"
 
-    (testpath/"receipt-contract.json").write <<~JSON
-      {"skill_decision_contract":{"contract_version":"SKDC-v1","skill":{"name":"tap-skill","kind":"decision","source_fingerprint":"tap-v1"},"triggers":[{"trigger_id":"T1","description":"tap trigger","cue_literals":["tap"],"cue_regexes":[],"exclusions":[]}],"routes":[{"route_id":"R1","description":"tap route","aliases":[],"terminal":true}],"clauses":[{"clause_id":"C1","trigger_refs":["T1"],"expected_routes":["R1"],"prohibited_routes":[],"required_artifacts":["receipt"],"success_signals":[],"failure_signals":[],"rationale":"tap coverage"}],"instrumentation":{"decision_receipt":"required","rationale":"tap coverage"}}}
+    (testpath/"observation.json").write <<~JSON
+      {
+        "schema":"seq-observation-definition/v1",
+        "id":"tap/active-facts",
+        "requires":{"abi":"seq-observation-abi/v1","operators":["filter","project"]},
+        "parameters":{},"selectors":[],"relations":[],
+        "inputs":[{"name":"facts","schema":"tap-facts/v1","fields":[
+          {"name":"id","type":"string","nullable":false},
+          {"name":"active","type":"boolean","nullable":false}
+        ],"max_rows":2,"max_bytes":1024}],
+        "pipeline":[
+          {"op":"filter","input":"facts","as":"matched","where":[{"field":"active","op":"exact","value":true}]},
+          {"op":"project","input":"matched","as":"rows","fields":["id"]}
+        ],
+        "projections":{"rows":{"relation":"rows","schema":"tap-active/v1","fields":["id"],"renderers":["json"]}},
+        "bounds":{"max_rows":2,"max_output_bytes":1024,"max_fold_states":1,"max_input_bytes":1024}
+      }
     JSON
-    receipt_projection = shell_output(
-      "#{bin}/seq skill-contract validate --file #{testpath}/receipt-contract.json --format json",
+    (testpath/"facts.json").write <<~JSON
+      {"schema":"tap-facts/v1","rows":[{"id":"first","active":false},{"id":"second","active":true}]}
+    JSON
+
+    check_output = shell_output(
+      "#{bin}/seq definition check --definition #{testpath}/observation.json --format json",
     )
-    assert_match '"valid": true', receipt_projection
-    assert_match '"skill_kind": "decision"', receipt_projection
-    assert_match '"clause_routes": [{"clause_id": "C1"', receipt_projection
-    token_help = shell_output("#{bin}/seq token-usage --help")
-    assert_match "--tz", token_help
-    assert_match "--last", token_help
-    assert_match "--summary", token_help
-    assert_match "--audit", token_help
+    check = JSON.parse(check_output)
+    assert check.fetch("valid")
+    assert check.fetch("passive")
+    refute check.fetch("authority_granted")
 
-    token_cost_help = shell_output("#{bin}/seq token-cost --help")
-    assert_match "--pricing", token_cost_help
-    assert_match "--model", token_cost_help
-
-    skill_audit_help = shell_output("#{bin}/seq skill-audit --help")
-    assert_match "summary|mentions|trend|activation", skill_audit_help
-    assert_match "--exclude-current", skill_audit_help
-    assert_match "--last", skill_audit_help
-    assert_match "summary|sessions", shell_output("#{bin}/seq skill-success-rank --help")
-    skill_blocks_help = shell_output("#{bin}/seq skill-blocks --help")
-    assert_match "blocks|body|term-counts|term-summary", skill_blocks_help
-    assert_match "term-counts", skill_blocks_help
-    assert_match "term-summary", skill_blocks_help
-    assert_match "--term-group", skill_blocks_help
-    assert_match "summary|rows|args|unresolved", shell_output("#{bin}/seq tool-audit --help")
-    assert_match "categories|files|blocks|stage1|extensions", shell_output("#{bin}/seq memory-inventory --help")
-    assert_match "--contains-any", shell_output("#{bin}/seq message-search --help")
-    assert_match "summary|sessions", shell_output("#{bin}/seq workdir-report --help")
-    artifact_search_help = shell_output("#{bin}/seq artifact-search --help")
-    assert_match "--contains-any", artifact_search_help
-    assert_match "summary|rows|sessions", shell_output("#{bin}/seq message-audit --help")
-    skill_cohort_help = shell_output("#{bin}/seq skill-cohort --help")
-    assert_match "summary|cohort|mentions", skill_cohort_help
-    assert_match "--last", skill_cohort_help
-    tool_search_help = shell_output("#{bin}/seq tool-search --help")
-    assert_match "rows|summary|args", tool_search_help
-    assert_match "--path", tool_search_help
-    assert_match "--session-id", tool_search_help
-    assert_match "--contains-any", tool_search_help
-    assert_match "summary|rows", shell_output("#{bin}/seq memory-extension-audit --help")
-    assert_match "--window-hours", shell_output("#{bin}/seq token-window --help")
-    assert_match "review|resolve", shell_output("#{bin}/seq goal-audit --help")
-    workflow_audit_help = shell_output("#{bin}/seq workflow-audit --help")
-    assert_match "cohort-report", workflow_audit_help
-    assert_match "term-summary", workflow_audit_help
-    assert_match "--term-group", workflow_audit_help
-    assert_match "--last", workflow_audit_help
-    adjudication_help = shell_output("#{bin}/seq adjudication-audit --help")
-    assert_match "summary|rows|report", adjudication_help
-    assert_match "--include-root-equivalent", adjudication_help
-    assert_match "--bundle-dir", adjudication_help
-
-    resolve_churn_help = shell_output("#{bin}/seq resolve-churn-audit --help")
-    assert_match "--since", resolve_churn_help
-    assert_match "--until", resolve_churn_help
-    assert_match "--repo", resolve_churn_help
-    assert_match "markdown|json", resolve_churn_help
-
-    review_compiler_help = shell_output("#{bin}/seq review-compiler-audit --help")
-    assert_match "--since", review_compiler_help
-    assert_match "--until", review_compiler_help
-    assert_match "--repo", review_compiler_help
-    assert_match "--protocol", review_compiler_help
-    assert_match "c3-mrpc", review_compiler_help
-    assert_match "mbk", review_compiler_help
-    assert_match "table|json|jsonl|markdown", review_compiler_help
-
-    execution_policy_help = shell_output("#{bin}/seq execution-policy-audit --help")
-    assert_match "summary|runs|policies|transitions|calibration|regret|proof|report", execution_policy_help
-    assert_match "--policy-root", execution_policy_help
-
-    execution_policy_compile_help = shell_output("#{bin}/seq execution-policy-compile --help")
-    assert_match "--file", execution_policy_compile_help
-    assert_match "--format json", execution_policy_compile_help
-
-    actuation_audit_help = shell_output("#{bin}/seq actuation-audit --help")
-    assert_match "summary|runs|slices|proof|compactions|decisions|kernel|report", actuation_audit_help
-
-    session_dir = testpath/"sessions/2026/05/13"
-    session_dir.mkpath
-    (session_dir/"rollout-c3-orphan.jsonl").write <<~JSONL
-      {"type":"session_meta","timestamp":"2026-05-13T12:00:00Z","payload":{"id":"c3-orphan-closed","cwd":"#{testpath}","model":"gpt-5"}}
-      {"type":"event_msg","timestamp":"2026-05-13T12:00:01Z","payload":{"type":"agent_message","turn_id":"x1","message":"MRPC-v1 minimal_review_patch_certificate\\nclosed"}}
-    JSONL
-    review_compiler_audit = shell_output(
-      "#{bin}/seq review-compiler-audit " \
-      "--root #{testpath}/sessions --protocol c3 " \
-      "--since 2026-05-13T00:00:00Z --until 2026-05-14T00:00:00Z " \
-      "--repo #{testpath} --format json",
+    result_output = shell_output(
+      "#{bin}/seq observe --definition #{testpath}/observation.json " \
+      "--input facts=#{testpath}/facts.json --projection rows --format json",
     )
-    assert_match "\"included_sessions\"", review_compiler_audit
-    assert_match "\"reason\": \"no_c3_begin_signal\"", review_compiler_audit
-    assert_match "\"state\": \"declared_uncontrolled\"", review_compiler_audit
-    assert_match "\"c3_closed\": false", review_compiler_audit
-    assert_match "\"summary_state\": \"NONE\"", review_compiler_audit
-
-    decision_capsule_help = shell_output("#{bin}/seq decision-capsule --help")
-    assert_match "capsule|candidates|anchors|validate", decision_capsule_help
-    assert_match "--thread-id", decision_capsule_help
-    assert_match "--mode", decision_capsule_help
-    assert_match "--format", decision_capsule_help
-    assert_match "table|json|jsonl|csv|markdown", decision_capsule_help
-
-    decision_capsules_schema = shell_output(
-      "#{bin}/seq dataset-schema --dataset decision_capsules --format json",
-    )
-    assert_match "decision_capsules", decision_capsules_schema
-
-    historical_decisions_schema = shell_output(
-      "#{bin}/seq dataset-schema --dataset historical_decisions --format json",
-    )
-    assert_match "historical_decisions", historical_decisions_schema
-
-    execution_policy_schema = shell_output(
-      "#{bin}/seq dataset-schema --dataset execution_policy_transitions --format json",
-    )
-    assert_match "execution_policy_transitions", execution_policy_schema
-    assert_match "transition_audits", execution_policy_schema
+    result = JSON.parse(result_output)
+    assert_equal "seq-observation-result/v1", result.fetch("schema")
+    assert_equal [{ "id" => "second" }], result.dig("data", "rows")
+    refute result.fetch("authority_granted")
   end
 end


### PR DESCRIPTION
## What changed

- publish Seq 1.0.0 and Ledger 1.0.0 formulas
- remove Ledger's obsolete runtime dependency on Seq
- replace retired domain-command formula tests with small generic definition compilation and execution proofs
- publish the coupled CAS 0.3.4 and memory-note 0.1.12 archives

## Why

Seq and Ledger now expose passive-definition kernels with a hard-cutover command surface. The tap must install the exact released archives and test those generic boundaries without retaining the retired commands or domain fixtures.

## Proof

- all four release tags resolve to skills-zig merge `6c47cc741d9c0c742f60f546c707f5a53b612536` and tree `097c9c5032c637791795d81cc2fc6327e9a62c9a`
- downloaded macOS archives match the formula SHA-256 values
- extracted binaries report Seq 1.0.0, Ledger 1.0.0, CAS 0.3.4, and memory-note 0.1.12
- release binaries pass generic Seq definition/observation and Ledger definition/validation smokes
- `brew style Formula/seq.rb Formula/ledger.rb Formula/cas.rb Formula/memory-note.rb`
