### PR TITLE
Release Seq 1.0.1

### DIFF
--- a/Formula/seq.rb
+++ b/Formula/seq.rb
@@ -1,17 +1,17 @@
 class Seq < Formula
   desc "Native observation compiler for agent session evidence"
   homepage "https://github.com/tkersey/skills-zig"
-  version "1.0.0"
+  version "1.0.1"
   license "MIT"
 
   if OS.mac?
     depends_on arch: :arm64
     url "https://github.com/tkersey/skills-zig/releases/download/seq-v#{version}/seq-v#{version}-darwin-arm64.tar.gz"
-    sha256 "a236cabe32334fa888fbae4456fd87b9ec8123ba4f016abf11f24649e6934667"
+    sha256 "9b14a3042dc583083e00354d7e45a7604ab4eb16dc3dba8e69fdfd75f5817399"
   else
     depends_on arch: :x86_64
     url "https://github.com/tkersey/skills-zig/releases/download/seq-v#{version}/seq-v#{version}-linux-x86_64.tar.gz"
-    sha256 "4cae5649607173ead8cb9232060773e1ff7e274b78933cc728a378af1709d6f6"
+    sha256 "e58907377d35b2728a7d0ab24029bc86d3bebe48e4334e7a1efe6236cd57a743"
   end
 
   def install


### PR DESCRIPTION
<!-- ship-proof:start -->
## Summary
- Update the Seq formula from 1.0.0 to 1.0.1.
- Bind macOS arm64 and Linux x86_64 downloads to the published Seq 1.0.1 asset digests.

## Proof
- Seq release workflow `30495257370`: pass for Darwin arm64, Linux x86_64, and publication.
- Tag `seq-v1.0.1` resolves to skills-zig merge commit `fa19cbf31fd51641cd9b2af39354a73a663f9753`.
- Darwin asset SHA-256: `9b14a3042dc583083e00354d7e45a7604ab4eb16dc3dba8e69fdfd75f5817399`.
- Linux asset SHA-256: `e58907377d35b2728a7d0ab24029bc86d3bebe48e4334e7a1efe6236cd57a743`.
- Downloaded Darwin binary reports `1.0.1`, the expected observation ABI, and preserved numeric sequence behavior.
- `brew style Formula/seq.rb`: pass.

## Scope
- repository: `tkersey/homebrew-tap`
- branch: `release/seq-1.0.1`
- head: `00165d136582420aa0229d7427608ce91c8659c2`
- base: `main`
- base SHA: `8e4d9cc3008f1ef605476c64e6088b31c7745930`

## Risks
- The formula is platform-gated exactly as before: macOS arm64 and Linux x86_64.

## Follow-ups
- Run the exact named-formula Homebrew audit, upgrade, test, and Fish startup proof after landing.

## Readiness
- Operation: create
- Final state: ready
- SHIP-v1 compatibility mode: ready
- Reason: the published release tuple, asset bytes, formula digests, and Ruby style are verified.
- Caveats: Homebrew disables path-based formula audit; the exact named-formula audit runs immediately after merge.
<!-- ship-proof:end -->
