### PR TITLE
Release Seq 1.0.2, CAS 0.3.5, Ledger 1.0.1, and memory-note 0.1.13

### DIFF
--- a/Formula/cas.rb
+++ b/Formula/cas.rb
@@ -1,16 +1,16 @@
 class Cas < Formula
   desc "Zig CLI helpers for Codex app-server orchestration"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.3.4"
+  version "0.3.5"
 
   depends_on "tkersey/tap/ledger"
 
   if OS.mac?
     url "https://github.com/tkersey/skills-zig/releases/download/cas-v#{version}/cas-v#{version}-darwin-arm64.tar.gz"
-    sha256 "2a693f270db087afda3d12c584bac89819bf1720991f7f2331bd1677163f11de"
+    sha256 "7afbde7d55a746e788443e422c110d6c52e8b702db7d1d8361348abd906733ac"
   else
     url "https://github.com/tkersey/skills-zig/releases/download/cas-v#{version}/cas-v#{version}-linux-x86_64.tar.gz"
-    sha256 "023c208d659a153c648cbb48d7c98026e14f6168209b7b32c3afada02ed3dfcc"
+    sha256 "6fe83eefa76851d13b2756c2d05ce0c0152482e7976d37c2a5b53f99a752f243"
   end
 
   on_macos do

--- a/Formula/ledger.rb
+++ b/Formula/ledger.rb
@@ -1,15 +1,15 @@
 class Ledger < Formula
   desc "Native artifact validation and durable protocol runtime"
   homepage "https://github.com/tkersey/skills-zig"
-  version "1.0.0"
+  version "1.0.1"
   license "MIT"
 
   if OS.mac?
     url "https://github.com/tkersey/skills-zig/releases/download/ledger-v#{version}/ledger-v#{version}-darwin-arm64.tar.gz"
-    sha256 "f55fee27fa5b6d0d409bd8dcd268404b8e1bd71f9a0d3033e863e86fc415190d"
+    sha256 "4d109e8e51b442dcf207d9d4f936d0e62a46a10b92731250a3c2992dfd3e0e3e"
   else
     url "https://github.com/tkersey/skills-zig/releases/download/ledger-v#{version}/ledger-v#{version}-linux-x86_64.tar.gz"
-    sha256 "c2029a321b9ae925fb3c9834a1003cde5237dcc08dbf65b5b398e12a9e6c0236"
+    sha256 "7e6cdd8471f476f23a3de68290f9bc54f6efb96b09dc609798eded71f25f5444"
   end
 
   on_macos do

--- a/Formula/memory-note.rb
+++ b/Formula/memory-note.rb
@@ -1,15 +1,15 @@
 class MemoryNote < Formula
   desc "Safe append-only custom Codex memory-source note writer"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.1.12"
+  version "0.1.13"
   license "MIT"
 
   if OS.mac?
     url "https://github.com/tkersey/skills-zig/releases/download/memory-note-v#{version}/memory-note-v#{version}-darwin-arm64.tar.gz"
-    sha256 "48407eaa0e155ff7399aeef39dfacb31914b3da78111f1e04ddf1d8eca8296c0"
+    sha256 "7398b6f122145f2243ba3f546140d7609a9823891b3e84cf61138fcaef557895"
   else
     url "https://github.com/tkersey/skills-zig/releases/download/memory-note-v#{version}/memory-note-v#{version}-linux-x86_64.tar.gz"
-    sha256 "d4fd71f451e2a2be0b1a68d2497f31c6b29a88e4c080e6a080b175cfeb04d284"
+    sha256 "eb625b9de9c17b95b2f6ec25cf27b3673534c78daba95f0dc4407afddf49289b"
   end
 
   on_macos do

--- a/Formula/seq.rb
+++ b/Formula/seq.rb
@@ -1,17 +1,17 @@
 class Seq < Formula
   desc "Native observation compiler for agent session evidence"
   homepage "https://github.com/tkersey/skills-zig"
-  version "1.0.1"
+  version "1.0.2"
   license "MIT"
 
   if OS.mac?
     depends_on arch: :arm64
     url "https://github.com/tkersey/skills-zig/releases/download/seq-v#{version}/seq-v#{version}-darwin-arm64.tar.gz"
-    sha256 "9b14a3042dc583083e00354d7e45a7604ab4eb16dc3dba8e69fdfd75f5817399"
+    sha256 "d568f6f2b2f544a48d842751db528053203e15337537d24b09d219766283dc34"
   else
     depends_on arch: :x86_64
     url "https://github.com/tkersey/skills-zig/releases/download/seq-v#{version}/seq-v#{version}-linux-x86_64.tar.gz"
-    sha256 "e58907377d35b2728a7d0ab24029bc86d3bebe48e4334e7a1efe6236cd57a743"
+    sha256 "0ccd12b51f9034f301cbadd6942f2ec7f43fcfe5ba2dc711103af61c0d78a3ba"
   end
 
   def install


### PR DESCRIPTION
## Summary

- release Seq 1.0.2
- release CAS 0.3.5
- release Ledger 1.0.1
- release memory-note 0.1.13
- bind each macOS and Linux formula checksum to the corresponding published `skills-zig` release asset

These versions contain the durable-store recovery and filesystem-identity fixes merged in `skills-zig` PR #97. CAS continues to depend on the independently versioned Ledger formula.

## Verification

- all four release workflows completed successfully from `skills-zig` merge commit `330290e59ab6eaeb7f4985753e3f0f1cf7a29b0b`
- all eight release assets are published with matching GitHub SHA-256 digests
- `ruby -c` passes for all four changed formulas
- `git diff --check` passes

After merge, closure will run tap-qualified Homebrew audit, upgrade, test, and installed-version checks for all four formulas.
