### PR TITLE
Keep CAS Ledger runtime private

### DIFF
--- a/Formula/cas.rb
+++ b/Formula/cas.rb
@@ -21,15 +21,17 @@ class Cas < Formula
 
   def install
     bin.install "cas"
-    bin.install "ledger"
     bin.install "cas_account"
     bin.install "cas-conformance-suite" => "cas_conformance_suite"
     bin.install "cas-goal" => "cas_goal"
     bin.install "cas-smoke-check" => "cas_smoke_check"
     bin.install "cas-instance-runner" => "cas_instance_runner"
     bin.install "cas-review-session" => "cas_review_session"
-    bin.install "cas-session-inquiry" => "cas_session_inquiry"
     bin.install "cas-perf-budget-governor"
+
+    libexec.install "ledger", "cas_session_inquiry"
+    bin.write_exec_script libexec/"cas_session_inquiry"
+    bin.install_symlink "cas_session_inquiry" => "cas-session-inquiry"
   end
 
   test do
@@ -38,7 +40,8 @@ class Cas < Formula
     assert_match "Subcommands:", cas_help
     assert_match "goal", cas_help
 
-    ledger_help = shell_output("#{bin}/ledger --help 2>&1")
+    refute_path_exists bin/"ledger"
+    ledger_help = shell_output("#{libexec}/ledger --help 2>&1")
     assert_match "Passive definitions for validation", ledger_help
     assert_match "ledger definition check", ledger_help
 


### PR DESCRIPTION
Fixes the CAS 0.3.9 Homebrew link conflict with the standalone Ledger formula.

The CAS release remains a closed runtime unit, but its exact bundled Ledger is installed privately under `libexec`. `cas_session_inquiry` is colocated there and exposed through wrapper entrypoints, so it resolves the private sibling without claiming the global `ledger` command.

This was reproduced by upgrading a machine with `ledger 1.0.1` already installed; direct `bin.install "ledger"` failed at Homebrew link time.

Proof: `ruby -c Formula/cas.rb`; `brew style Formula/cas.rb`; `git diff --check`. The public install/upgrade proof will be rerun after merge.