### PR TITLE
Update CAS to 0.3.12

### DIFF
--- a/Formula/cas.rb
+++ b/Formula/cas.rb
@@ -1,14 +1,14 @@
 class Cas < Formula
   desc "Zig CLI helpers for Codex app-server orchestration"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.3.11"
+  version "0.3.12"
 
   if OS.mac?
     url "https://github.com/tkersey/skills-zig/releases/download/cas-v#{version}/cas-v#{version}-darwin-arm64.tar.gz"
-    sha256 "1a2fb7b2b2719a418b1103e62284f39b7e453323700956779c7482de147fb718"
+    sha256 "e38346e4eba6ee8b3c1f62871f9966cb47b149738d92373a46f8c450ab32909b"
   else
     url "https://github.com/tkersey/skills-zig/releases/download/cas-v#{version}/cas-v#{version}-linux-x86_64.tar.gz"
-    sha256 "4a7f92880c5c073d98f33f5426e82a5c0615aab67b3497a2ef749f340379e8d5"
+    sha256 "c66e1fd640ee34201aad851d3722f7541778be6f6b27bc5cbe44bc08cfc8de2a"
   end
 
   on_macos do


### PR DESCRIPTION
<!-- ship-proof:start -->
## Summary
- Publish CAS 0.3.12 through Homebrew.
- Bind both platform formulas to the checksums reported by the `cas-v0.3.12` release assets.

## Proof
- `brew style Formula/cas.rb`: pass, no offenses
- `ruby -c Formula/cas.rb`: syntax OK
- `git diff --check`: pass
- GitHub release `cas-v0.3.12`: published with darwin-arm64 and linux-x86_64 assets

## Scope
- repository: tkersey/homebrew-tap
- branch: release/cas-0.3.12
- head: ab217bc0c3914140f6388b9efa0b7dd9300aec6a
- base: main
- base SHA: 2ba2707399843bcd631d392ab9e38ca520fcd8ed

## Risks
- Formula-only release propagation; no CLI behavior changes occur in this repository.

## Follow-ups
- After merge, update the local tap, run strict audit/test, reinstall, and verify `cas --version`.

## Readiness
- Operation: create
- Final state: ready
- SHIP-v1 compatibility mode: ready
- Reason: release assets exist and formula syntax/style validation is green
- Caveats: none
<!-- ship-proof:end -->
