### PR TITLE
Update CAS to 0.5.0

### DIFF
--- a/Formula/cas.rb
+++ b/Formula/cas.rb
@@ -1,14 +1,14 @@
 class Cas < Formula
   desc "Local Codex control-plane CLI"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.4.1"
+  version "0.5.0"
 
   if OS.mac?
     url "https://github.com/tkersey/skills-zig/releases/download/cas-v#{version}/cas-v#{version}-darwin-arm64.tar.gz"
-    sha256 "72a7739e5210de2b52fc4f7bcdbb92996a391394720d96874f782740659d7b2c"
+    sha256 "a10c27b5b40ffd882df9bbd490d7b01f2b9243f9404efaabef9c39adbfb9bc7d"
   else
     url "https://github.com/tkersey/skills-zig/releases/download/cas-v#{version}/cas-v#{version}-linux-x86_64.tar.gz"
-    sha256 "98341b386d8d88097162afc27af769a6bb568425c78cb67999b9120f8bb436c2"
+    sha256 "d97bf79860d7e1029b5e2eba2b2f711a6ad4d4e1cb2923fe0ef72f39967ac55a"
   end
 
   on_macos do

--- a/Formula/cas.rb
+++ b/Formula/cas.rb
@@ -89,7 +89,7 @@ class Cas < Formula
     capabilities = shell_output("#{bin}/cas capabilities --json")
     assert_match "\"cas_rer_opaque_request_binding_v1\": true", capabilities
     assert_match "\"cas_review_scoped_instructions_v1\": true", capabilities
-    assert_match "\"cas_app_server_contract_0146_v1\": true", capabilities
+    assert_match "\"cas_app_server_contract_v1\": true", capabilities
     assert_match "\"cas_automation_v1\": true", capabilities
 
     inquiry_help = shell_output("#{bin}/cas_session_inquiry --help 2>&1")


### PR DESCRIPTION
Updates the CAS formula to the capability-based 0.5.0 release and binds the exact published macOS and Linux SHA-256 digests.\n\nVerified locally:\n- `brew style Formula/cas.rb`\n- `ruby -c Formula/cas.rb`