### PR TITLE
Release Synoptic and affected Homebrew formulas

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,10 +41,18 @@ jobs:
       - name: Reject skipped or failed formulae
         if: always() && github.event_name == 'pull_request'
         env:
+          ALLOWED_SKIPPED_FORMULAE: ${{ runner.os == 'Linux' && 'tkersey/tap/synoptic' || '' }}
           SKIPPED_OR_FAILED_FORMULAE: ${{ steps.formulae.outputs.skipped_or_failed_formulae }}
         run: |
-          if [ -n "${SKIPPED_OR_FAILED_FORMULAE}" ]; then
-            echo "::error::Skipped or failed formulae: ${SKIPPED_OR_FAILED_FORMULAE}"
+          unexpected=''
+          for formula in ${SKIPPED_OR_FAILED_FORMULAE}; do
+            case " ${ALLOWED_SKIPPED_FORMULAE} " in
+              *" ${formula} "*) ;;
+              *) unexpected="${unexpected} ${formula}" ;;
+            esac
+          done
+          if [ -n "${unexpected}" ]; then
+            echo "::error::Unexpected skipped or failed formulae:${unexpected}"
             exit 1
           fi
 

--- a/Formula/cas.rb
+++ b/Formula/cas.rb
@@ -1,14 +1,14 @@
 class Cas < Formula
   desc "Local Codex control-plane CLI"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.5.1"
+  version "0.5.2"
 
   if OS.mac?
     url "https://github.com/tkersey/skills-zig/releases/download/cas-v#{version}/cas-v#{version}-darwin-arm64.tar.gz"
-    sha256 "4c74aba3c2c3bd18c31c04dc793e1742f1a5f6ee01f3a910ea6fabd179ca0831"
+    sha256 "e701d86ac0b2fba5ffbb4cd3f437d9459fa1f3213669b9634301b81e5404cbb9"
   else
     url "https://github.com/tkersey/skills-zig/releases/download/cas-v#{version}/cas-v#{version}-linux-x86_64.tar.gz"
-    sha256 "91023f6477bb50e73305b48136761eab69ed1f1455de4d01711976f840406d25"
+    sha256 "0a7c01c65649924c31a27e921ee37bd9723120255eca0201fce2bc4cd8e8cc2b"
   end
 
   on_macos do

--- a/Formula/ledger.rb
+++ b/Formula/ledger.rb
@@ -1,15 +1,15 @@
 class Ledger < Formula
   desc "Native artifact validation and durable protocol runtime"
   homepage "https://github.com/tkersey/skills-zig"
-  version "1.1.0"
+  version "1.1.1"
   license "MIT"
 
   if OS.mac?
     url "https://github.com/tkersey/skills-zig/releases/download/ledger-v#{version}/ledger-v#{version}-darwin-arm64.tar.gz"
-    sha256 "eb8f9b31f59d8b555d07c8d8e973e73e46b8d4f5bcb3fbd2c3d7550e72068b57"
+    sha256 "38f922b9b9bf5f3f82ba26a970122f539215fd49863a3f0485254704691d1ad4"
   else
     url "https://github.com/tkersey/skills-zig/releases/download/ledger-v#{version}/ledger-v#{version}-linux-x86_64.tar.gz"
-    sha256 "d9e57e3e74006feff65bc3f83b5b56c03a49d3c6fbfb3e1a9d413a5bef20b9f8"
+    sha256 "4b39248a760550877980daff12297869c8251c94a0ac406dccd8bf6d9641853d"
   end
 
   on_macos do

--- a/Formula/memory-note.rb
+++ b/Formula/memory-note.rb
@@ -1,15 +1,15 @@
 class MemoryNote < Formula
   desc "Safe append-only custom Codex memory-source note writer"
   homepage "https://github.com/tkersey/skills-zig"
-  version "0.1.14"
+  version "0.1.15"
   license "MIT"
 
   if OS.mac?
     url "https://github.com/tkersey/skills-zig/releases/download/memory-note-v#{version}/memory-note-v#{version}-darwin-arm64.tar.gz"
-    sha256 "5328ca4c30258f67db8d1f0fa6df33e1df7e41e3d32179fae6fd8a38dec91d6f"
+    sha256 "c6d5060b2903aef3ae1ea1a8fa220997ce8ffe22f102f3721829d4ee490a0a92"
   else
     url "https://github.com/tkersey/skills-zig/releases/download/memory-note-v#{version}/memory-note-v#{version}-linux-x86_64.tar.gz"
-    sha256 "40ef79a8d0eb29c5e07963d374a198c4534fa2365d5f59f0ecd30bb765f9c57f"
+    sha256 "2196951f7433accdde2343c8f348aa5376371bde398137b9f00389342c342bb3"
   end
 
   on_macos do

--- a/Formula/seq.rb
+++ b/Formula/seq.rb
@@ -1,17 +1,17 @@
 class Seq < Formula
   desc "Native observation compiler for agent session evidence"
   homepage "https://github.com/tkersey/skills-zig"
-  version "1.1.1"
+  version "1.1.2"
   license "MIT"
 
   if OS.mac?
     depends_on arch: :arm64
     url "https://github.com/tkersey/skills-zig/releases/download/seq-v#{version}/seq-v#{version}-darwin-arm64.tar.gz"
-    sha256 "9f166293bea62e0a9a775480a87c53f5fcad6b6573dad3893b2a73b9d1f63ceb"
+    sha256 "abb4246aa75bbf7bc8da4ea45f54df943912cacd969ab7fd06601907534f464e"
   else
     depends_on arch: :x86_64
     url "https://github.com/tkersey/skills-zig/releases/download/seq-v#{version}/seq-v#{version}-linux-x86_64.tar.gz"
-    sha256 "d8739f66b2790aff961a510695728cae4c028fd9e545bb4903a8f37e6f552789"
+    sha256 "68281b8817d1ae91933a4f434a97b36c2dc78cfbf4ea4455a6d1b5e7f653e64f"
   end
 
   def install

--- a/Formula/synoptic.rb
+++ b/Formula/synoptic.rb
@@ -1,0 +1,32 @@
+class Synoptic < Formula
+  desc "Interactive per-file pull-request review workbench"
+  homepage "https://github.com/tkersey/skills-zig"
+  version "0.1.0"
+  license "MIT"
+
+  if Hardware::CPU.arm?
+    url "https://github.com/tkersey/skills-zig/releases/download/synoptic-v#{version}/synoptic-v#{version}-darwin-arm64.tar.gz"
+    sha256 "837201d1a0a70c6b34bc7cebd289dd344c17f43152e11f8c68fa09db69b5ce65"
+  else
+    url "https://github.com/tkersey/skills-zig/releases/download/synoptic-v#{version}/synoptic-v#{version}-darwin-x86_64.tar.gz"
+    sha256 "0098e972095d6b26b1c4e1a6a4f170736f09396f20234ac646881804e57bd7dd"
+  end
+
+  depends_on :macos
+
+  def install
+    bin.install "synoptic"
+  end
+
+  test do
+    assert_equal version.to_s, shell_output("#{bin}/synoptic --version").strip
+
+    capabilities = JSON.parse(shell_output("#{bin}/synoptic capabilities --format json"))
+    synoptic = capabilities.fetch("synopticCapabilities")
+    assert_equal version.to_s, synoptic.fetch("version")
+    assert_equal "macos", synoptic.fetch("platform")
+    assert_equal "synoptic-skill-abi/v1", synoptic.fetch("skillAbi")
+    assert_equal "synoptic-ui/v1", synoptic.fetch("uiAbi")
+    assert synoptic.fetch("features").values.all?
+  end
+end

--- a/Formula/synoptic.rb
+++ b/Formula/synoptic.rb
@@ -19,7 +19,7 @@ class Synoptic < Formula
   end
 
   test do
-    assert_equal version.to_s, shell_output("#{bin}/synoptic --version").strip
+    assert_equal "synoptic #{version}", shell_output("#{bin}/synoptic --version").strip
 
     capabilities = JSON.parse(shell_output("#{bin}/synoptic capabilities --format json"))
     synoptic = capabilities.fetch("synopticCapabilities")


### PR DESCRIPTION
## Summary

- add the macOS-only Synoptic 0.1.0 formula
- update Seq to 1.1.2, CAS to 0.5.2, Ledger to 1.1.1, and Memory Note to 0.1.15
- bind every formula to the published GitHub release checksum

## Validation

- `brew style` passes for all five formulas
- release assets and SHA-256 digests were read from the published GitHub releases
- strict named-formula audit, install/upgrade, and `brew test` will run after merge against the refreshed tap